### PR TITLE
percollate 4.2.3 (new formula)

### DIFF
--- a/Formula/p/percollate.rb
+++ b/Formula/p/percollate.rb
@@ -1,0 +1,22 @@
+class Percollate < Formula
+  desc "CLI to turn web pages into readable PDF, EPUB, HTML, or Markdown docs"
+  homepage "https://github.com/danburzo/percollate"
+  url "https://registry.npmjs.org/percollate/-/percollate-4.2.3.tgz"
+  sha256 "a14bba93972213434a383de1e1ce720fd53ccf67283179c14f347686ae2c0c90"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/percollate --version")
+
+    # Since percollate requires Chromium, just do a error check in here
+    output = shell_output("#{bin}/percollate pdf https://example.com -o my.pdf 2>&1", 1)
+    assert_match "Could not find Chromium", output
+  end
+end


### PR DESCRIPTION
use negative test due to the error below:

```
$ /opt/homebrew/Cellar/percollate/4.2.3/bin/percollate pdf https://example.com -o example.pdf
Fetching: https://example.com ✓
Enhancing web page: https://example.com ✓
file:///opt/homebrew/Cellar/percollate/4.2.3/libexec/lib/node_modules/percollate/node_modules/puppeteer-core/lib/esm/puppeteer/node/ProductLauncher.js:263
                    throw new Error(`Could not find Chromium (rev. ${this.puppeteer.browserRevision}). This can occur if either\n` +
                          ^

Error: Could not find Chromium (rev. 1108766). This can occur if either
 1. you did not perform an installation before running the script (e.g. `npm install`) or
 2. your cache path is incorrectly configured (which is: /Users/rui/.cache/puppeteer).
For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.
    at ChromeLauncher.resolveExecutablePath (file:///opt/homebrew/Cellar/percollate/4.2.3/libexec/lib/node_modules/percollate/node_modules/puppeteer-core/lib/esm/puppeteer/node/ProductLauncher.js:263:27)
    at ChromeLauncher.executablePath (file:///opt/homebrew/Cellar/percollate/4.2.3/libexec/lib/node_modules/percollate/node_modules/puppeteer-core/lib/esm/puppeteer/node/ChromeLauncher.js:176:25)
    at ChromeLauncher.computeLaunchArguments (file:///opt/homebrew/Cellar/percollate/4.2.3/libexec/lib/node_modules/percollate/node_modules/puppeteer-core/lib/esm/puppeteer/node/ChromeLauncher.js:93:37)
    at async ChromeLauncher.launch (file:///opt/homebrew/Cellar/percollate/4.2.3/libexec/lib/node_modules/percollate/node_modules/puppeteer-core/lib/esm/puppeteer/node/ProductLauncher.js:57:28)
    at async bundlePdf (file:///opt/homebrew/Cellar/percollate/4.2.3/libexec/lib/node_modules/percollate/index.js:500:18)
    at async generate (file:///opt/homebrew/Cellar/percollate/4.2.3/libexec/lib/node_modules/percollate/index.js:770:3)
    at async pdf (file:///opt/homebrew/Cellar/percollate/4.2.3/libexec/lib/node_modules/percollate/index.js:782:9)

Node.js v23.7.0
```