### PR TITLE
mcp-reasoner 2.0.0 (new formula)

### DIFF
--- a/Formula/m/mcp-reasoner.rb
+++ b/Formula/m/mcp-reasoner.rb
@@ -1,0 +1,31 @@
+class McpReasoner < Formula
+  desc "MCP server for beam search and thought evaluation"
+  homepage "https://github.com/Jacck/mcp-reasoner"
+  url "https://registry.npmjs.org/@mseep/mcp-reasoner/-/mcp-reasoner-2.0.0.tgz"
+  sha256 "cf03037abee12121e720fa38bf04983d3729c1f01af525a555aba3c21fa86084"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+
+    (bin/"mcp-reasoner").write <<~SH
+      #!/bin/bash
+      exec "#{Formula["node"].opt_bin}/node" \
+        "#{libexec}/lib/node_modules/@mseep/mcp-reasoner/dist/index.js" "$@"
+    SH
+  end
+
+  test do
+    json = <<~JSON
+      {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"homebrew","version":"1.0"}}}
+      {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+      {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+    JSON
+
+    output = pipe_output(bin/"mcp-reasoner", json, 0)
+    assert_match "\"name\":\"mcp-reasoner\"", output
+    assert_match "\"strategyType\"", output
+  end
+end


### PR DESCRIPTION
```
> fd index.js /opt/homebrew/Cellar/mcp-reasoner/2.0.0
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/dist/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/@modelcontextprotocol/sdk/dist/cjs/client/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/@modelcontextprotocol/sdk/dist/cjs/client/index.js.map
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/index.js.map
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js.map
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js.map
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/accepts/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/ajv/lib/compile/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/ajv/lib/dotjs/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/body-parser/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/bytes/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/call-bind-apply-helpers/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/call-bind-apply-helpers/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/call-bound/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/call-bound/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/chalk/source/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/chalk/source/vendor/ansi-styles/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/chalk/source/vendor/supports-color/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/content-disposition/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/content-type/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/cookie/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/cookie-signature/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/cors/lib/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/cross-spawn/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/debug/src/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/depd/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/depd/lib/browser/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/dunder-proto/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/ee-first/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/encodeurl/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/es-define-property/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/es-define-property/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/es-errors/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/es-errors/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/es-object-atoms/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/es-object-atoms/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/escape-html/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/etag/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/eventsource/dist/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/eventsource/dist/index.js.map
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/eventsource-parser/dist/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/eventsource-parser/dist/index.js.map
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/express/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/fast-deep-equal/es6/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/fast-deep-equal/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/fast-json-stable-stringify/benchmark/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/fast-json-stable-stringify/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/finalhandler/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/forwarded/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/fresh/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/function-bind/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/function-bind/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/get-intrinsic/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/get-proto/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/get-proto/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/gopd/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/gopd/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/has-symbols/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/has-symbols/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/hasown/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/http-errors/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/http-errors/node_modules/statuses/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/iconv-lite/encodings/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/iconv-lite/lib/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/is-promise/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/isexe/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/json-schema-traverse/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/math-intrinsics/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/media-typer/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/merge-descriptors/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/mime-db/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/mime-types/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/ms/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/negotiator/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/object-assign/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/object-inspect/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/on-finished/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/parseurl/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/path-key/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/path-to-regexp/dist/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/path-to-regexp/dist/index.js.map
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/proxy-addr/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/qs/lib/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/range-parser/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/raw-body/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/router/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/safe-buffer/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/send/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/serve-static/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/setprototypeof/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/setprototypeof/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/shebang-command/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/shebang-regex/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/side-channel/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/side-channel/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/side-channel-list/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/side-channel-list/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/side-channel-map/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/side-channel-map/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/side-channel-weakmap/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/side-channel-weakmap/test/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/statuses/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/toidentifier/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/type-is/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/unpipe/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/uri-js/dist/esnext/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/uri-js/dist/esnext/index.js.map
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/uuid/dist/commonjs-browser/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/uuid/dist/esm-browser/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/uuid/dist/esm-node/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/uuid/dist/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/vary/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod/v3/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod/v4/classic/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod/v4/core/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod/v4/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod/v4/locales/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod/v4/mini/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod/v4-mini/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod-to-json-schema/dist/cjs/index.js
/opt/homebrew/Cellar/mcp-reasoner/2.0.0/libexec/lib/node_modules/@mseep/mcp-reasoner/node_modules/zod-to-json-schema/dist/esm/index.js
```