### PR TITLE
renovate: label renovate prs with syntax-only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,9 @@
   ],
   platformAutomerge: true,
   labels: [
+    'CI-syntax-only',
     'dependencies',
+    'renovate',
   ],
   vulnerabilityAlerts: {
     enabled: true,


### PR DESCRIPTION
currently it would trigger the pr-pull flow per https://github.com/chenrui333/homebrew-tap/pull/1956, mark the renovate prs as syntax-only

<img width="409" height="107" alt="image" src="https://github.com/user-attachments/assets/6e58a742-d93a-4c84-97ee-1e41febd7815" />
