### PR TITLE
crush: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/c/crush.rb
+++ b/Formula/c/crush.rb
@@ -18,8 +18,6 @@ class Crush < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = "-s -w -X github.com/charmbracelet/crush/internal/version.Version=#{version}"
     system "go", "build", *std_go_args(ldflags:)
 


### PR DESCRIPTION
split from https://github.com/chenrui333/homebrew-tap/pull/2035