### PR TITLE
adbtuifm: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/a/adbtuifm.rb
+++ b/Formula/a/adbtuifm.rb
@@ -19,8 +19,6 @@ class Adbtuifm < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 


### PR DESCRIPTION
- split from #2035