### PR TITLE
autotag: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/a/autotag.rb
+++ b/Formula/a/autotag.rb
@@ -19,8 +19,6 @@ class Autotag < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./autotag"
   end
 


### PR DESCRIPTION
- split from #2035