### PR TITLE
awless: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/a/awless.rb
+++ b/Formula/a/awless.rb
@@ -25,8 +25,6 @@ class Awless < Formula
   end
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     system "go", "build", *std_go_args(ldflags: "-s -w"), "-mod=readonly"
   end
 


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035