### PR TITLE
axiom-mcp-server: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/a/axiom-mcp-server.rb
+++ b/Formula/a/axiom-mcp-server.rb
@@ -18,8 +18,6 @@ class AxiomMcpServer < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = "-s -w -X main.Version=#{version} -X main.CommitSHA=#{tap.user} -X main.BuildTime=#{time.iso8601}"
     system "go", "build", *std_go_args(ldflags:)
   end


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035