### PR TITLE
az-tui: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/a/az-tui.rb
+++ b/Formula/a/az-tui.rb
@@ -19,8 +19,6 @@ class AzTui < Formula
   depends_on "azure-cli"
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = %W[
       -s -w
       -X github.com/IAL32/az-tui/internal/build.Version=#{version}


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035