### PR TITLE
certok: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/c/certok.rb
+++ b/Formula/c/certok.rb
@@ -22,8 +22,6 @@ class Certok < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = %W[
       -s -w
       -X github.com/genuinetools/certok/version.VERSION=#{version}


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035