### PR TITLE
cf-cf-vault: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/c/cf-vault.rb
+++ b/Formula/c/cf-vault.rb
@@ -20,8 +20,6 @@ class CfVault < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = "-s -w -s -w -X github.com/jacobbednarz/cf-vault/cmd.Rev=#{version}"
     system "go", "build", *std_go_args(ldflags:)
 


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035