### PR TITLE
cloudlens: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/c/cloudlens.rb
+++ b/Formula/c/cloudlens.rb
@@ -20,8 +20,6 @@ class Cloudlens < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = %W[
       -s -w
       -X github.com/one2nc/cloudlens/cmd.version=#{version}


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035