### PR TITLE
cmdx: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/c/cmdx.rb
+++ b/Formula/c/cmdx.rb
@@ -20,8 +20,6 @@ class Cmdx < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = "-s -w -X main.version=#{version} -X main.commit=#{tap.user} -X main.date=#{time.iso8601}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/cmdx"
   end


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035