### PR TITLE
cocainate: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/c/cocainate.rb
+++ b/Formula/c/cocainate.rb
@@ -20,8 +20,6 @@ class Cocainate < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = %W[
       -s -w
       -X github.com/AppleGamer22/cocainate/commands.Version=#{version}


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035