### PR TITLE
cohctl: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/c/cohctl.rb
+++ b/Formula/c/cohctl.rb
@@ -20,8 +20,6 @@ class Cohctl < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = "-s -w -X main.Version=#{version} -X main.Commit=#{tap.user} -X main.Date=#{time.iso8601}"
     system "go", "build", *std_go_args(ldflags:), "./cohctl"
 


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035