### PR TITLE
container2wasm: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/c/container2wasm.rb
+++ b/Formula/c/container2wasm.rb
@@ -19,8 +19,6 @@ class Container2wasm < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = %W[
       -s -w
       -X github.com/ktock/container2wasm/version.Version=#{version}


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035