### PR TITLE
elastop: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/e/elastop.rb
+++ b/Formula/e/elastop.rb
@@ -19,8 +19,6 @@ class Elastop < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035