### PR TITLE
infraspec: Remove CGO_ENABLED workaround for linux arm build

### DIFF
--- a/Formula/i/infraspec.rb
+++ b/Formula/i/infraspec.rb
@@ -19,8 +19,6 @@ class Infraspec < Formula
   depends_on "go" => :build
 
   def install
-    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
-
     ldflags = "-s -w -X github.com/robmorgan/infraspec/internal/build.Version=#{version}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/infraspec"
 


### PR DESCRIPTION
- split from https://github.com/chenrui333/homebrew-tap/pull/2035