### PR TITLE
workflows/autobump: qualify formulae with tap name to resolve conflicts

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -42,7 +42,7 @@ jobs:
         id: autobump
         run: |
           autobump_list=$(brew tap-info chenrui333/homebrew-tap --json | \
-            jq -c -r '.[0]["formula_names"] | join(" ")')
+            jq -c -r '.[0]["formula_names"] | map("chenrui333/tap/" + .) | join(" ")')
           echo "autobump_list=$autobump_list" >> "$GITHUB_OUTPUT"
 
       - name: Bump formulae


### PR DESCRIPTION
Prefix formula names with chenrui333/tap/ so autobump can resolve formulae that exist in multiple taps.

---

seeing https://github.com/chenrui333/homebrew-tap/actions/runs/19215334964/job/54923801004#step:5:563

```
==> copilot-cli
Current formula version:  0.0.327
Latest livecheck version: 0.0.354
Duplicate pull requests:  none
Maybe duplicate pull requests: copilot-cli 0.0.327 (new formula) (https://github.com/chenrui333/homebrew-tap/pull/1741)
Error: Formulae found in multiple taps:
       * chenrui333/tap/copilot-cli
       * aws/tap/copilot-cli

Please use the fully-qualified name (e.g. chenrui333/tap/copilot-cli) to refer to a specific formula.
```