### PR TITLE
kyanos 1.5.1 (new formula)

### DIFF
--- a/Formula/k/kyanos.rb
+++ b/Formula/k/kyanos.rb
@@ -19,6 +19,9 @@ class Kyanos < Formula
       ENV.append "GOFLAGS", "-buildmode=pie"
     end
 
+    # Upstream expects generated eBPF objects to exist before `go build`.
+    system "make", "build-bpf"
+
     ldflags = %W[
       -s -w
       -X kyanos/version.Version=#{version}

--- a/Formula/k/kyanos.rb
+++ b/Formula/k/kyanos.rb
@@ -1,0 +1,34 @@
+class Kyanos < Formula
+  desc "Networking analysis tool using eBPF"
+  homepage "https://kyanos.io/"
+  url "https://github.com/hengyoush/kyanos/archive/refs/tags/v1.5.1.tar.gz"
+  sha256 "832976e747eeb6c86fb0fb1e031eeb3a6d3d020dc998c214cb8a31ffac5f4b08"
+  license "Apache-2.0"
+  head "https://github.com/hengyoush/kyanos.git", branch: "main"
+
+  depends_on "go" => :build
+  depends_on "libbpf"
+  depends_on :linux
+
+  def install
+    ENV["CGO_ENABLED"] = "1"
+
+    # Workaround to avoid patchelf corruption when cgo is required
+    if OS.linux? && Hardware::CPU.arch == :arm64
+      ENV["GO_EXTLINK_ENABLED"] = "1"
+      ENV.append "GOFLAGS", "-buildmode=pie"
+    end
+
+    ldflags = %W[
+      -s -w
+      -X kyanos/version.Version=#{version}
+      -X kyanos/version.CommitID=#{tap.user}
+      -X kyanos/version.BuildTime=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/kyanos --version")
+  end
+end

--- a/Formula/k/kyanos.rb
+++ b/Formula/k/kyanos.rb
@@ -7,11 +7,20 @@ class Kyanos < Formula
   head "https://github.com/hengyoush/kyanos.git", branch: "main"
 
   depends_on "go" => :build
-  depends_on "libbpf"
+  depends_on "llvm" => :build
+  depends_on "pkgconf" => :build
+  depends_on "elfutils"
   depends_on :linux
+  depends_on "zlib-ng-compat"
+
+  resource "libbpf" do
+    url "https://github.com/libbpf/libbpf/archive/e0554200338152aa5c9ffe635a5c312a0a0e86dc.tar.gz"
+    sha256 "1726ab89357fb41b575680e010f37f6ac1c3329c43aba63f9901fa8aea06d300"
+  end
 
   def install
     ENV["CGO_ENABLED"] = "1"
+    ENV.prepend_path "PATH", Formula["llvm"].opt_bin
 
     # Workaround to avoid patchelf corruption when cgo is required
     if OS.linux? && Hardware::CPU.arch == :arm64
@@ -20,7 +29,8 @@ class Kyanos < Formula
     end
 
     # Upstream expects generated eBPF objects to exist before `go build`.
-    system "make", "build-bpf"
+    resource("libbpf").stage buildpath/"libbpf"
+    system "make", "build-bpf", "CLANG=#{Formula["llvm"].opt_bin/"clang"}"
 
     ldflags = %W[
       -s -w

--- a/Formula/k/kyanos.rb
+++ b/Formula/k/kyanos.rb
@@ -42,7 +42,7 @@ class Kyanos < Formula
   end
 
   test do
-    assert_match "Version: #{version}", shell_output("#{bin}/kyanos version")
-    assert_match "watch HTTP message", shell_output("#{bin}/kyanos watch http --help")
+    assert_match "Version: #{version}", shell_output("#{bin}/kyanos version 2>&1")
+    assert_match "watch HTTP message", shell_output("#{bin}/kyanos watch http --help 2>&1")
   end
 end

--- a/Formula/k/kyanos.rb
+++ b/Formula/k/kyanos.rb
@@ -43,6 +43,6 @@ class Kyanos < Formula
 
   test do
     assert_match "Version: #{version}", shell_output("#{bin}/kyanos version 2>&1")
-    assert_match "watch HTTP message", shell_output("#{bin}/kyanos watch http --help 2>&1")
+    assert_match "Filter HTTP messages based on method", shell_output("#{bin}/kyanos watch http --help 2>&1")
   end
 end

--- a/Formula/k/kyanos.rb
+++ b/Formula/k/kyanos.rb
@@ -42,6 +42,7 @@ class Kyanos < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/kyanos --version")
+    assert_match "Version: #{version}", shell_output("#{bin}/kyanos version")
+    assert_match "watch HTTP message", shell_output("#{bin}/kyanos watch http --help")
   end
 end


### PR DESCRIPTION
Built and tested locally on macOS where applicable.

Adds kyanos 1.5.1. macOS source install is blocked by the expected Linux requirement; style and new-formula audit pass locally.
