### PR TITLE
wiremix 0.10.0 (new formula)

### DIFF
--- a/Formula/w/wiremix.rb
+++ b/Formula/w/wiremix.rb
@@ -1,8 +1,8 @@
 class Wiremix < Formula
   desc "TUI audio mixer for PipeWire"
   homepage "https://github.com/tsowell/wiremix"
-  url "https://github.com/tsowell/wiremix/archive/refs/tags/v0.8.0.tar.gz"
-  sha256 "db357d21c76809d674024f1094c2ac6ddd2d6866d4b8ae53cbb0620599006e31"
+  url "https://github.com/tsowell/wiremix/archive/refs/tags/v0.9.0.tar.gz"
+  sha256 "9fd8979fa3bc260a80d170c30041ab2aeea26273439bac8ce928a9405ce1d0f5"
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/tsowell/wiremix.git", branch: "main"
 

--- a/Formula/w/wiremix.rb
+++ b/Formula/w/wiremix.rb
@@ -1,0 +1,21 @@
+class Wiremix < Formula
+  desc "TUI audio mixer for PipeWire"
+  homepage "https://github.com/tsowell/wiremix"
+  url "https://github.com/tsowell/wiremix/archive/refs/tags/v0.8.0.tar.gz"
+  sha256 "db357d21c76809d674024f1094c2ac6ddd2d6866d4b8ae53cbb0620599006e31"
+  license any_of: ["Apache-2.0", "MIT"]
+  head "https://github.com/tsowell/wiremix.git", branch: "main"
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on :linux
+  depends_on "pipewire"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "wiremix #{version}", shell_output("#{bin}/wiremix --version")
+  end
+end

--- a/Formula/w/wiremix.rb
+++ b/Formula/w/wiremix.rb
@@ -11,7 +11,13 @@ class Wiremix < Formula
   depends_on :linux
   depends_on "pipewire"
 
+  on_linux do
+    depends_on "llvm" => :build
+  end
+
   def install
+    ENV["LIBCLANG_PATH"] = Formula["llvm"].opt_lib if OS.linux?
+
     system "cargo", "install", *std_cargo_args
   end
 

--- a/Formula/w/wiremix.rb
+++ b/Formula/w/wiremix.rb
@@ -22,6 +22,6 @@ class Wiremix < Formula
   end
 
   test do
-    assert_match "wiremix #{version}", shell_output("#{bin}/wiremix --version")
+    assert_match "wiremix v#{version}", shell_output("#{bin}/wiremix --version")
   end
 end

--- a/Formula/w/wiremix.rb
+++ b/Formula/w/wiremix.rb
@@ -1,8 +1,8 @@
 class Wiremix < Formula
   desc "TUI audio mixer for PipeWire"
   homepage "https://github.com/tsowell/wiremix"
-  url "https://github.com/tsowell/wiremix/archive/refs/tags/v0.9.0.tar.gz"
-  sha256 "9fd8979fa3bc260a80d170c30041ab2aeea26273439bac8ce928a9405ce1d0f5"
+  url "https://github.com/tsowell/wiremix/archive/refs/tags/v0.10.0.tar.gz"
+  sha256 "dfb165ff664b804099c5592fd26d2b03d78e67069522bc5d3d8ef75a19505adf"
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/tsowell/wiremix.git", branch: "main"
 


### PR DESCRIPTION
Built and tested locally on macOS.

Updated to v0.10.0. This formula is Linux-only, so the local macOS install stops at the expected Linux requirement.
