### PR TITLE
codemachine 0.8.0 (new formula)

### DIFF
--- a/Formula/c/codemachine.rb
+++ b/Formula/c/codemachine.rb
@@ -1,18 +1,32 @@
 class Codemachine < Formula
-  desc "CLI-native orchestration engine for autonomous workflows and production-ready code"
+  desc "CLI-native orchestration engine for autonomous coding workflows"
   homepage "https://codemachine.co/"
-  url "https://registry.npmjs.org/codemachine/-/codemachine-0.7.0.tgz"
-  sha256 "931959597c409a1dbf60a2edd1e8416e3f8ffc2a2aa9d7c8d30db3b313404c8b"
+  url "https://registry.npmjs.org/codemachine/-/codemachine-0.8.0.tgz"
+  sha256 "13b5b78d7e33e1d6733e8dce05e5b4d41173db44465f6ca559172b517890bcdd"
   license "Apache-2.0"
 
   depends_on "node"
 
   def install
     system "npm", "install", *std_npm_args
+
+    # These platform-specific OpenTUI artifacts are not used by the shipped CLI binary
+    # and their install IDs are not relocatable in Homebrew builds.
+    libexec.glob("lib/node_modules/codemachine/node_modules/**/@opentui/core-*").each do |path|
+      rm_r path
+    end
+    libexec.glob("lib/node_modules/codemachine/node_modules/**/*.dylib").each do |path|
+      rm path
+    end
+
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/codemachine --version")
+    (testpath/"project").mkpath
+    cd testpath/"project" do
+      assert_match version.to_s, shell_output("#{bin}/codemachine --version")
+      assert_match "too many arguments", shell_output("#{bin}/codemachine invalid-command 2>&1", 1)
+    end
   end
 end

--- a/Formula/c/codemachine.rb
+++ b/Formula/c/codemachine.rb
@@ -1,0 +1,18 @@
+class Codemachine < Formula
+  desc "CLI-native orchestration engine for autonomous workflows and production-ready code"
+  homepage "https://codemachine.co/"
+  url "https://registry.npmjs.org/codemachine/-/codemachine-0.7.0.tgz"
+  sha256 "931959597c409a1dbf60a2edd1e8416e3f8ffc2a2aa9d7c8d30db3b313404c8b"
+  license "Apache-2.0"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/codemachine --version")
+  end
+end

--- a/Formula/c/codemachine.rb
+++ b/Formula/c/codemachine.rb
@@ -5,6 +5,7 @@ class Codemachine < Formula
   sha256 "13b5b78d7e33e1d6733e8dce05e5b4d41173db44465f6ca559172b517890bcdd"
   license "Apache-2.0"
 
+  depends_on "chenrui333/tap/bun"
   depends_on "node"
 
   def install


### PR DESCRIPTION
Built and tested locally on macOS 26.4.1.

Adds codemachine 0.8.0 as a new formula.
