### PR TITLE
ironclaw 0.5.0 (new formula)

### DIFF
--- a/Formula/i/ironclaw.rb
+++ b/Formula/i/ironclaw.rb
@@ -7,6 +7,7 @@ class Ironclaw < Formula
   head "https://github.com/nearai/ironclaw.git", branch: "main"
 
   depends_on "rust" => :build
+  depends_on "openssl@3"
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/i/ironclaw.rb
+++ b/Formula/i/ironclaw.rb
@@ -1,0 +1,21 @@
+class Ironclaw < Formula
+  desc "Security-first personal AI assistant with WASM sandbox channels"
+  homepage "https://github.com/nearai/ironclaw"
+  url "https://github.com/nearai/ironclaw/archive/refs/tags/v0.5.0.tar.gz"
+  sha256 "e60ef7e056f643ccdd7ae0437abd64bad5884ecffde62edac85e2ebd31ec71b8"
+  license any_of: ["MIT", "Apache-2.0"]
+  head "https://github.com/nearai/ironclaw.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    ENV["HOME"] = testpath
+
+    assert_match version.to_s, shell_output("#{bin}/ironclaw --version")
+    assert_match "Settings", shell_output("#{bin}/ironclaw config list")
+  end
+end

--- a/Formula/i/ironclaw.rb
+++ b/Formula/i/ironclaw.rb
@@ -12,6 +12,11 @@ class Ironclaw < Formula
     system "cargo", "install", *std_cargo_args
   end
 
+  service do
+    run [opt_bin/"ironclaw", "run"]
+    keep_alive true
+  end
+
   test do
     ENV["HOME"] = testpath
 

--- a/Formula/i/ironclaw.rb
+++ b/Formula/i/ironclaw.rb
@@ -6,6 +6,7 @@ class Ironclaw < Formula
   license any_of: ["MIT", "Apache-2.0"]
   head "https://github.com/nearai/ironclaw.git", branch: "main"
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"
 


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Adds a new formula for IronClaw, a security-first personal AI assistant with WASM sandbox channels.