### PR TITLE
moltis 0.9.0 (new formula)

### DIFF
--- a/Formula/m/moltis.rb
+++ b/Formula/m/moltis.rb
@@ -1,0 +1,43 @@
+class Moltis < Formula
+  desc "Local-first personal AI gateway with plugin-driven channels"
+  homepage "https://moltis.org/"
+  url "https://github.com/moltis-org/moltis/archive/refs/tags/v0.9.0.tar.gz"
+  sha256 "bc0b42c2b276e1778c65b8bc823e642e4dd7b63ac533cde3ed5a0017962d74c3"
+  license "MIT"
+  head "https://github.com/moltis-org/moltis.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on "openssl@3"
+
+  on_linux do
+    depends_on "llvm" => :build
+    depends_on "zlib-ng-compat"
+  end
+
+  def install
+    if OS.linux?
+      zlib = Formula["zlib-ng-compat"]
+      ENV["LIBCLANG_PATH"] = Formula["llvm"].opt_lib.to_s
+      ENV["ZLIB_ROOT"] = zlib.opt_prefix.to_s
+      ENV.append_path "PKG_CONFIG_PATH", zlib.opt_lib/"pkgconfig"
+      ENV.append "LDFLAGS", "-L#{zlib.opt_lib}"
+      ENV.append "CPPFLAGS", "-I#{zlib.opt_include}"
+    end
+
+    system "cargo", "install", *std_cargo_args(path: "crates/cli")
+  end
+
+  service do
+    run [opt_bin/"moltis", "gateway"]
+    keep_alive true
+  end
+
+  test do
+    ENV["HOME"] = testpath
+
+    assert_match version.to_s, shell_output("#{bin}/moltis --version")
+    assert_match "No issues found.", shell_output("#{bin}/moltis config check 2>&1")
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Adds a new formula for Moltis, a local-first personal AI gateway with a plugin-driven channel architecture.