### PR TITLE
zeptoclaw 0.4.0 (new formula)

### DIFF
--- a/Formula/z/zeptoclaw.rb
+++ b/Formula/z/zeptoclaw.rb
@@ -1,0 +1,26 @@
+class Zeptoclaw < Formula
+  desc "Lightweight personal AI gateway with layered safety controls"
+  homepage "https://zeptoclaw.com/"
+  url "https://github.com/qhkm/zeptoclaw/archive/refs/tags/v0.4.0.tar.gz"
+  sha256 "2ad0028eb7afef751e3a8c2eb8eee3a6be38bda3ff88029140ff4d740452592c"
+  license "Apache-2.0"
+  head "https://github.com/qhkm/zeptoclaw.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  service do
+    run [opt_bin/"zeptoclaw", "gateway"]
+    keep_alive true
+  end
+
+  test do
+    ENV["HOME"] = testpath
+
+    assert_match version.to_s, shell_output("#{bin}/zeptoclaw --version")
+    assert_match "No config file found", shell_output("#{bin}/zeptoclaw config check")
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Adds a new formula for ZeptoClaw, a lightweight personal AI gateway with layered safety controls and channel extensibility.