### PR TITLE
ci: baseline unstable links in link-checker

### DIFF
--- a/Formula/s/spacelift-intent.rb
+++ b/Formula/s/spacelift-intent.rb
@@ -30,7 +30,7 @@ class SpaceliftIntent < Formula
     JSON
 
     output = +""
-    Open3.popen2e(bin/"spacelift-intent") do |stdin, stdout_err, wait_thr|
+    Open3.popen2e(bin/"spacelift-intent") do |stdin, stdout_err, wait_thread|
       stdin.write json
       stdin.close
 
@@ -41,7 +41,7 @@ class SpaceliftIntent < Formula
         output << stdout_err.readpartial(1024)
       end
 
-      Process.kill("TERM", wait_thr.pid) if wait_thr.alive?
+      Process.kill("TERM", wait_thread.pid) if wait_thread.alive?
     end
 
     assert_match "# Infrastructure Management - Essential Instructions", output

--- a/lychee.toml
+++ b/lychee.toml
@@ -26,6 +26,8 @@ exclude = [
   "^https://github\\.com/ascorbic/mapscii/?$",
   "^https://rustwasm\\.github\\.io/twiggy/?$",
   "^https://github\\.com/ODwyerSoftware/brunette/?$",
+  "^https://beelzebub-honeypot\\.com/?$",
+  "^https://fnc\\.bsdbox\\.org/index/?$",
   "^https://www\\.gnu\\.org/software/hello/?$",
 ]
 


### PR DESCRIPTION
## Summary
- add lychee excludes for https://beelzebub-honeypot.com/ (timeout seen in run 22200141376)
- add lychee exclude for https://fnc.bsdbox.org/index (connection refused during full local sweep)

## Validation
- lychee --config ./lychee.toml --no-progress formula-status/formula-status.md
- lychee --config ./lychee.toml --no-progress README.md cmd docs claudedocs formula-status
