### PR TITLE
triage: run Spell Check on pull_request

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,6 +1,7 @@
 name: Triage tasks
 
 on:
+  pull_request:
   pull_request_target:
 
 concurrency:
@@ -10,6 +11,7 @@ concurrency:
 jobs:
   triage:
     if: |
+      github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.type != 'Bot' &&
       github.event.pull_request.state == 'open'
@@ -137,6 +139,7 @@ jobs:
 
   typos:
     name: Spell Check
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -5,7 +5,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: "triage-${{ github.event.number }}"
+  group: "triage-${{ github.event.pull_request.number }}-${{ github.event_name }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Built and tested locally on macOS.

Run Spell Check on pull_request so typos validates PR code, while keeping label triage logic on pull_request_target.

Closes #4397
