### PR TITLE
ironclaw: remove unnecessary HOME in test

### DIFF
--- a/Formula/i/ironclaw.rb
+++ b/Formula/i/ironclaw.rb
@@ -29,8 +29,6 @@ class Ironclaw < Formula
   end
 
   test do
-    ENV["HOME"] = testpath
-
     assert_match version.to_s, shell_output("#{bin}/ironclaw --version")
     assert_match "Settings", shell_output("#{bin}/ironclaw config list")
   end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Removes unnecessary `ENV["HOME"] = testpath` from the `ironclaw` formula test block.
