### PR TITLE
moltis: remove unnecessary HOME in test

### DIFF
--- a/Formula/m/moltis.rb
+++ b/Formula/m/moltis.rb
@@ -44,8 +44,6 @@ class Moltis < Formula
   end
 
   test do
-    ENV["HOME"] = testpath
-
     assert_match version.to_s, shell_output("#{bin}/moltis --version")
     assert_match "No issues found.", shell_output("#{bin}/moltis config check 2>&1")
   end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Removes unnecessary `ENV["HOME"] = testpath` from the `moltis` formula test block.
