### PR TITLE
nullclaw: remove unnecessary HOME in test

### DIFF
--- a/Formula/n/nullclaw.rb
+++ b/Formula/n/nullclaw.rb
@@ -28,8 +28,6 @@ class Nullclaw < Formula
   end
 
   test do
-    ENV["HOME"] = testpath
-
     output = shell_output("#{bin}/nullclaw status 2>&1")
     assert_match "nullclaw Status", output
     assert_match "Provider:    openrouter", output


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Removes unnecessary `ENV["HOME"] = testpath` from the `nullclaw` formula test block.
