### PR TITLE
zeptoclaw: remove unnecessary HOME in test

### DIFF
--- a/Formula/z/zeptoclaw.rb
+++ b/Formula/z/zeptoclaw.rb
@@ -27,8 +27,6 @@ class Zeptoclaw < Formula
   end
 
   test do
-    ENV["HOME"] = testpath
-
     assert_match version.to_s, shell_output("#{bin}/zeptoclaw --version")
     assert_match "No config file found", shell_output("#{bin}/zeptoclaw config check")
   end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Removes unnecessary `ENV["HOME"] = testpath` from the `zeptoclaw` formula test block.
