### PR TITLE
xytz 0.8.4 (new formula)

### DIFF
--- a/Formula/x/xytz.rb
+++ b/Formula/x/xytz.rb
@@ -1,0 +1,28 @@
+class Xytz < Formula
+  desc "Beautiful TUI YouTube downloader"
+  homepage "https://github.com/xdagiz/xytz"
+  url "https://github.com/xdagiz/xytz/archive/refs/tags/v0.8.4.tar.gz"
+  sha256 "4db513109e87419af5a915e97daa5303ba8e1394eafc7211be24840647bdc744"
+  license "MIT"
+  head "https://github.com/xdagiz/xytz.git", branch: "main"
+
+  depends_on "go" => :build
+  depends_on "ffmpeg"
+  depends_on "yt-dlp"
+
+  def install
+    ldflags = "-s -w -X github.com/xdagiz/xytz/internal/version.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:)
+  end
+
+  test do
+    ENV["HOME"] = testpath
+    ENV["XDG_CONFIG_HOME"] = testpath/".config"
+
+    assert_match "Usage:", shell_output("#{bin}/xytz --help")
+
+    config = testpath/".config/xytz/config.yaml"
+    assert_path_exists config
+    assert_match "search_limit:", config.read
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 15.3.1.

Add a new `xytz` formula (v0.8.4) built from source with Go, with runtime dependencies on `ffmpeg` and `yt-dlp`.

Validation performed:
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source xytz`
- `brew test xytz`
- `brew style xytz`
- `brew linkage --test xytz`
- `brew audit --new xytz`
