### PR TITLE
polymaster 0.2.0 (new formula)

### DIFF
--- a/Formula/p/polymaster.rb
+++ b/Formula/p/polymaster.rb
@@ -1,0 +1,22 @@
+class Polymaster < Formula
+  desc "Monitor large transactions on Polymarket and Kalshi prediction markets"
+  homepage "https://github.com/neur0map/polymaster"
+  url "https://github.com/neur0map/polymaster/archive/95277b34c66eaa307d169cec45320ffa9f2403a0.tar.gz"
+  version "0.2.0"
+  sha256 "235e3078ee8a9a348d9d75389e7c6f5837c0f4dbd6b748c03b3c9b49b88f8fa7"
+  license :cannot_represent
+  head "https://github.com/neur0map/polymaster.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: ".")
+  end
+
+  test do
+    ENV["HOME"] = testpath
+
+    assert_match "Usage:", shell_output("#{bin}/wwatcher --help")
+    assert_match "WHALE WATCHER STATUS", shell_output("#{bin}/wwatcher status")
+  end
+end

--- a/Formula/p/polymaster.rb
+++ b/Formula/p/polymaster.rb
@@ -7,7 +7,12 @@ class Polymaster < Formula
   license :cannot_represent
   head "https://github.com/neur0map/polymaster.git", branch: "master"
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
+
+  on_linux do
+    depends_on "openssl@3"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args(path: ".")


### PR DESCRIPTION
Built and tested locally on macOS 15.3.1.

Add a new `polymaster` formula (v0.2.0) built from source with Rust.

Validation performed:
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source polymaster`
- `brew test polymaster`
- `brew style polymaster`
- `brew linkage --test polymaster`
- `brew audit --new polymaster`
