### PR TITLE
gokin 0.44.0 (new formula)

### DIFF
--- a/Formula/g/gokin.rb
+++ b/Formula/g/gokin.rb
@@ -1,0 +1,22 @@
+class Gokin < Formula
+  desc "AI-powered CLI assistant for code"
+  homepage "https://gokin.ginkida.dev"
+  url "https://github.com/ginkida/gokin/archive/refs/tags/v0.44.0.tar.gz"
+  sha256 "1c0c6d3f3a7c383efc0f9af60b1a9b08c397e2fcecd8f25629306a63ac5c49e4"
+  license "MIT"
+  head "https://github.com/ginkida/gokin.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/gokin"
+
+    generate_completions_from_executable(bin/"gokin", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gokin version")
+    assert_match "Available Commands:", shell_output("#{bin}/gokin --help")
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 15.3.1.

Add a new `gokin` formula (v0.44.0) built from source with Go.

Validation performed:
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source gokin`
- `brew test gokin`
- `brew style gokin`
- `brew linkage --test gokin`
- `brew audit --new gokin`
