### PR TITLE
jotbird 0.1.3 (new formula)

### DIFF
--- a/Formula/j/jotbird.rb
+++ b/Formula/j/jotbird.rb
@@ -1,0 +1,21 @@
+class Jotbird < Formula
+  desc "Publish Markdown from the command-line"
+  homepage "https://www.jotbird.com/cli"
+  url "https://github.com/jotbirdhq/jotbird-cli/archive/refs/tags/v0.1.3.tar.gz"
+  sha256 "10e04bd3a1a11ba4c3a85c34e5a00bfacc6841e664f1be6d9b6351bcd50ab3a4"
+  license "MIT"
+  head "https://github.com/jotbirdhq/jotbird-cli.git", branch: "main"
+
+  depends_on "node"
+
+  def install
+    system "npm", "run", "build"
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec/"bin/jotbird"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/jotbird --version")
+    assert_match "Not logged in", shell_output("#{bin}/jotbird list 2>&1", 1)
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Adds a new `jotbird` formula built from source.
