### PR TITLE
terminal-mcp 0.2.2 (new formula)

### DIFF
--- a/Formula/t/terminal-mcp.rb
+++ b/Formula/t/terminal-mcp.rb
@@ -30,7 +30,7 @@ class TerminalMcp < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/terminal-mcp --version")
-    output = shell_output("#{bin}/terminal-mcp --sandbox --sandbox-config #{testpath}/missing.json 2>&1", 1)
-    assert_match "Failed to load sandbox config", output
+    output = shell_output("TERMINAL_MCP=1 #{bin}/terminal-mcp 2>&1", 1)
+    assert_match "cannot be run from within itself", output
   end
 end

--- a/Formula/t/terminal-mcp.rb
+++ b/Formula/t/terminal-mcp.rb
@@ -26,6 +26,18 @@ class TerminalMcp < Formula
         rm_r path, force: true if path.basename.to_s != native_prebuild
       end
     end
+
+    return unless OS.linux?
+
+    native_seccomp = Hardware::CPU.arm? ? "arm64" : "x64"
+    seccomp_root = libexec/"lib/node_modules/@ellery/terminal-mcp/node_modules/@anthropic-ai/sandbox-runtime"
+    [seccomp_root/"dist/vendor/seccomp", seccomp_root/"vendor/seccomp"].each do |path|
+      next unless path.exist?
+
+      path.children.each do |child|
+        rm_r child, force: true if child.basename.to_s != native_seccomp
+      end
+    end
   end
 
   test do

--- a/Formula/t/terminal-mcp.rb
+++ b/Formula/t/terminal-mcp.rb
@@ -1,0 +1,30 @@
+class TerminalMcp < Formula
+  desc "Headless terminal emulator exposed via MCP for AI assistants"
+  homepage "https://github.com/elleryfamilia/terminal-mcp"
+  url "https://github.com/elleryfamilia/terminal-mcp/archive/refs/tags/v0.2.2.tar.gz"
+  sha256 "4f0a38362cc398978e885031a0387a63a530068d3af1d372d6c3cf68cbd54496"
+  license "MIT"
+  head "https://github.com/elleryfamilia/terminal-mcp.git", branch: "main"
+
+  depends_on "node"
+
+  def install
+    system "npm", "ci"
+    system "npm", "run", "build"
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec/"bin/terminal-mcp"
+
+    prebuilds = libexec/"lib/node_modules/@ellery/terminal-mcp/node_modules/node-pty/prebuilds"
+    if OS.mac? && Hardware::CPU.arm?
+      rm_r prebuilds/"darwin-x64", force: true
+    elsif OS.mac? && Hardware::CPU.intel?
+      rm_r prebuilds/"darwin-arm64", force: true
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/terminal-mcp --version")
+    output = shell_output("#{bin}/terminal-mcp --sandbox --sandbox-config #{testpath}/missing.json 2>&1", 1)
+    assert_match "Failed to load sandbox config", output
+  end
+end

--- a/Formula/t/terminal-mcp.rb
+++ b/Formula/t/terminal-mcp.rb
@@ -15,10 +15,16 @@ class TerminalMcp < Formula
     bin.install_symlink libexec/"bin/terminal-mcp"
 
     prebuilds = libexec/"lib/node_modules/@ellery/terminal-mcp/node_modules/node-pty/prebuilds"
-    if OS.mac? && Hardware::CPU.arm?
-      rm_r prebuilds/"darwin-x64", force: true
-    elsif OS.mac? && Hardware::CPU.intel?
-      rm_r prebuilds/"darwin-arm64", force: true
+    native_prebuild = if OS.mac?
+      Hardware::CPU.arm? ? "darwin-arm64" : "darwin-x64"
+    elsif OS.linux?
+      Hardware::CPU.arm? ? "linux-arm64" : "linux-x64"
+    end
+
+    if prebuilds.exist? && native_prebuild
+      prebuilds.children.each do |path|
+        rm_r path, force: true if path.basename.to_s != native_prebuild
+      end
     end
   end
 


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Adds a new `terminal-mcp` formula built from source.
