### PR TITLE
macime 4.2.0 (new formula)

### DIFF
--- a/Formula/m/macime.rb
+++ b/Formula/m/macime.rb
@@ -1,0 +1,26 @@
+class Macime < Formula
+  desc "Blazingly fast IME switcher for macOS"
+  homepage "https://github.com/riodelphino/macime"
+  url "https://github.com/riodelphino/macime/archive/refs/tags/v4.2.0.tar.gz"
+  sha256 "ec68e50bcc1e63e1a07592d40c2a4e3ae324b059b1e3702f1d89287798b85ce4"
+  license "MIT"
+  head "https://github.com/riodelphino/macime.git", branch: "4.x"
+
+  depends_on :macos
+
+  def install
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+    bin.install ".build/release/macime", ".build/release/macimed"
+  end
+
+  service do
+    run [opt_bin/"macimed"]
+    keep_alive true
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/macime --version")
+    assert_match version.to_s, shell_output("#{bin}/macimed --version")
+    assert_match "Invalid log level", shell_output("#{bin}/macimed --log-level nope 2>&1", 1)
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Adds a new `macime` formula built from source.
