### PR TITLE
sbomlyze 0.3.0 (new formula)

### DIFF
--- a/Formula/s/sbomlyze.rb
+++ b/Formula/s/sbomlyze.rb
@@ -1,0 +1,26 @@
+class Sbomlyze < Formula
+  desc "SBOM diff and analysis tool for software supply-chain security"
+  homepage "https://rezmoss.github.io/sbomlyze/"
+  url "https://github.com/rezmoss/sbomlyze/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "4f276a96d15a460927407a4991881651e4a1640667dc8b2e9e00e45a7705ed7f"
+  license "Apache-2.0"
+  head "https://github.com/rezmoss/sbomlyze.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/rezmoss/sbomlyze/internal/version.Version=#{version}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/sbomlyze"
+  end
+
+  test do
+    (testpath/"empty.json").write("{}")
+
+    assert_match version.to_s, shell_output("#{bin}/sbomlyze --version")
+    output = shell_output("#{bin}/sbomlyze #{testpath}/empty.json --no-pager")
+    assert_match "SBOM Statistics", output
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS and Linux.

New Go-based formula for `sbomlyze`.
