### PR TITLE
youtube-music-cli 0.0.27 (new formula)

### DIFF
--- a/Formula/y/youtube-music-cli.rb
+++ b/Formula/y/youtube-music-cli.rb
@@ -1,0 +1,34 @@
+class YoutubeMusicCli < Formula
+  desc "Terminal user interface music player for YouTube Music"
+  homepage "https://involvex.github.io/youtube-music-cli/"
+  url "https://github.com/involvex/youtube-music-cli/archive/refs/tags/v0.0.27.tar.gz"
+  sha256 "642e53b8a26a56ce4b4dae3b52ef4590ff2b76f74c7717ee351444a702e5315b"
+  license "MIT"
+  head "https://github.com/involvex/youtube-music-cli.git", branch: "main"
+
+  depends_on "bun" => :build
+  depends_on "mpv"
+  depends_on "node"
+  depends_on "yt-dlp"
+
+  def install
+    system "bun", "install", "--frozen-lockfile"
+    system "bun", "run", "build"
+
+    libexec.install Dir["*"]
+    rm_r Dir[libexec/"node_modules/.bun/node-notifier@*/vendor/mac.noindex/terminal-notifier.app"], force: true
+    rm_r libexec/"node_modules/node-notifier/vendor/mac.noindex/terminal-notifier.app", force: true
+    chmod 0755, libexec/"dist/source/cli.js"
+
+    (bin/"youtube-music-cli").write <<~SH
+      #!/bin/bash
+      exec "#{Formula["node"].opt_bin}/node" "#{libexec}/dist/source/cli.js" "$@"
+    SH
+    bin.install_symlink "youtube-music-cli" => "ymc"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/youtube-music-cli --version")
+    assert_match "No plugins installed.", shell_output("#{bin}/youtube-music-cli plugins list")
+  end
+end

--- a/Formula/y/youtube-music-cli.rb
+++ b/Formula/y/youtube-music-cli.rb
@@ -6,25 +6,21 @@ class YoutubeMusicCli < Formula
   license "MIT"
   head "https://github.com/involvex/youtube-music-cli.git", branch: "main"
 
-  depends_on "bun" => :build
   depends_on "mpv"
   depends_on "node"
   depends_on "yt-dlp"
 
   def install
-    system "bun", "install", "--frozen-lockfile"
-    system "bun", "run", "build"
+    system "npm", "install", "--include=dev", "--legacy-peer-deps",
+           *std_npm_args(prefix: false, ignore_scripts: false)
+    system "npm", "exec", "--", "tsc"
+    system "npm", "install", *std_npm_args
 
-    libexec.install Dir["*"]
-    rm_r Dir[libexec/"node_modules/.bun/node-notifier@*/vendor/mac.noindex/terminal-notifier.app"], force: true
-    rm_r libexec/"node_modules/node-notifier/vendor/mac.noindex/terminal-notifier.app", force: true
-    chmod 0755, libexec/"dist/source/cli.js"
-
-    (bin/"youtube-music-cli").write <<~SH
-      #!/bin/bash
-      exec "#{Formula["node"].opt_bin}/node" "#{libexec}/dist/source/cli.js" "$@"
-    SH
-    bin.install_symlink "youtube-music-cli" => "ymc"
+    notifier_app = "lib/node_modules/@involvex/youtube-music-cli/node_modules/" \
+                   "node-notifier/vendor/mac.noindex/terminal-notifier.app"
+    rm_r libexec/notifier_app, force: true
+    bin.install_symlink libexec/"bin/youtube-music-cli"
+    bin.install_symlink libexec/"bin/ymc"
   end
 
   test do


### PR DESCRIPTION
Built and tested locally on macOS and Linux.

Adds a new source-built formula for youtube-music-cli.
