### PR TITLE
typos: allow parm formula name

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -16,6 +16,8 @@ extend-ignore-re = [
 Hashi = "Hashi" 
 Sur = "Sur" 
 debugg = "debugg" # for debugg-ai-mcp filename
+parm = "parm" # formula name
+Parm = "Parm" # Ruby class name for formula
 sur = "sur" # for big sur
 yor = "yor" 
 


### PR DESCRIPTION
Allow `parm` / `Parm` in typos config for the formula name.
