### PR TITLE
ci: exclude cask notability audits

### DIFF
--- a/.github/workflows/cask-tests.yml
+++ b/.github/workflows/cask-tests.yml
@@ -157,7 +157,7 @@ jobs:
           (!matrix.cask || steps.fetch.outcome == 'success') &&
           !matrix.skip_audit
         run: |
-          brew audit --cask ${{ join(matrix.audit_args, ' ') }}${{ (matrix.cask && ' ') || ' --tap ' }}"${{ matrix.cask.token || matrix.tap }}"
+          brew audit --cask --except github_repository,gitlab_repository,bitbucket_repository,forgejo_repository ${{ join(matrix.audit_args, ' ') }}${{ (matrix.cask && ' ') || ' --tap ' }}"${{ matrix.cask.token || matrix.tap }}"
         timeout-minutes: 30
 
       - name: Gather cask information


### PR DESCRIPTION
Exclude repository notability audits in tap cask CI.

This updates `.github/workflows/cask-tests.yml` to pass:
- `--except github_repository,gitlab_repository,bitbucket_repository,forgejo_repository`

This is workflow-level behavior (no label gating).

----

- https://github.com/chenrui333/homebrew-tap/pull/4510
- https://github.com/chenrui333/homebrew-tap/pull/4511
- https://github.com/chenrui333/homebrew-tap/issues/4264
