### PR TITLE
triage: label new cask PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -32,6 +32,11 @@ jobs:
               path: Formula/.+
               allow_any_match: true
 
+            - label: new cask
+              status: added
+              path: Casks/.+
+              allow_any_match: true
+
             - label: linux-only
               path: Formula/.+
               content: depends_on :linux


### PR DESCRIPTION
Add auto-labeling for new cask pull requests in tap triage.

- Adds `new cask` label rule for added files under `Casks/**`
- Mirrors existing `new formula` behavior

Refs #4264
