### PR TITLE
ci: add cask automerge workflow

### DIFF
--- a/.github/workflows/cask-tests.yml
+++ b/.github/workflows/cask-tests.yml
@@ -285,3 +285,38 @@ jobs:
     steps:
       - name: Result
         run: ${{ needs.test.result == 'success' }}
+
+  label-pr:
+    needs: conclusion
+    if: success() && github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check if PR has 'in progress' label
+        id: check-label
+        run: |
+          LABELS=$(gh pr view "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
+          if echo "$LABELS" | grep -q "^in progress$"; then
+            echo "skip_label=true" >> "$GITHUB_ENV"
+          else
+            echo "skip_label=false" >> "$GITHUB_ENV"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+
+      - name: Ensure cask merge label exists
+        if: env.skip_label == 'false'
+        run: |
+          gh label create "pr-cask-merge" \
+            --color "0e8a16" \
+            --description "PR is ready for cask merge workflow" \
+            --repo "${{ github.repository }}" || true
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+
+      - name: Label the PR with 'pr-cask-merge'
+        if: env.skip_label == 'false'
+        run: gh pr edit "${{ github.event.pull_request.number }}" --add-label 'pr-cask-merge' --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}

--- a/.github/workflows/publish-cask.yml
+++ b/.github/workflows/publish-cask.yml
@@ -1,0 +1,44 @@
+name: brew cask-merge
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  cask-merge:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'pr-cask-merge') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.state == 'open' &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Validate changed files are cask-only
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mapfile -t files < <(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '.files[].path')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "PR has no changed files."
+            exit 1
+          fi
+
+          for file in "${files[@]}"; do
+            if [[ ! "$file" =~ ^Casks/ ]]; then
+              echo "Non-cask file detected in cask merge workflow: $file"
+              exit 1
+            fi
+          done
+
+      - name: Merge cask PR
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr merge "$PR_NUMBER" --merge --delete-branch --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Add dedicated cask automerge flow (no bottle `pr-pull` step).

- `cask-tests.yml`: add `label-pr` job to apply `pr-cask-merge` after successful cask CI
- `cask-tests.yml`: ensure `pr-cask-merge` label exists before applying
- `publish-cask.yml`: new workflow that merges `pr-cask-merge` PRs directly
- `publish-cask.yml`: gate merge to cask-only file changes (`Casks/**`)

Refs #4264
