### PR TITLE
ci: use squash merge for cask automerge

### DIFF
--- a/.github/workflows/publish-cask.yml
+++ b/.github/workflows/publish-cask.yml
@@ -41,4 +41,4 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr merge "$PR_NUMBER" --merge --delete-branch --repo "$GITHUB_REPOSITORY"
+          gh pr merge "$PR_NUMBER" --squash --delete-branch --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Fix cask automerge workflow to use a merge method allowed by this repository.

`publish-cask.yml` currently uses `gh pr merge --merge`, but this repository disallows merge commits.
This switches the command to `--squash` so labeled cask PRs can be auto-merged.


----

- https://github.com/chenrui333/homebrew-tap/pull/4510