### PR TITLE
betterleaks 1.0.1 (new formula)

### DIFF
--- a/Formula/b/betterleaks.rb
+++ b/Formula/b/betterleaks.rb
@@ -1,0 +1,43 @@
+class Betterleaks < Formula
+  desc "Secrets scanner built for configurability and speed"
+  homepage "https://github.com/betterleaks/betterleaks"
+  url "https://github.com/betterleaks/betterleaks/archive/refs/tags/v1.0.1.tar.gz"
+  sha256 "8f7d45ed52c58b793aaec84cdb04474c2e99d57b04de6cc40dd16f90a68de305"
+  license "MIT"
+  head "https://github.com/betterleaks/betterleaks.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/betterleaks/betterleaks/version.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:)
+
+    generate_completions_from_executable(bin/"betterleaks", shell_parameter_format: :cobra)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/betterleaks --version")
+
+    (testpath/"betterleaks.toml").write <<~TOML
+      title = "test-config"
+
+      [[rules]]
+      id = "custom-secret"
+      regex = '''SECRET_[A-Z0-9]{8}'''
+    TOML
+
+    (testpath/"secrets.txt").write "prefix SECRET_ABC12345 suffix\n"
+
+    report = testpath/"report.json"
+    shell_output(
+      "#{bin}/betterleaks dir --no-banner --log-level error " \
+      "--config #{testpath}/betterleaks.toml " \
+      "--report-format json --report-path #{report} #{testpath}/secrets.txt 2>&1",
+      1,
+    )
+
+    findings = JSON.parse(report.read)
+    assert_equal 1, findings.length
+    assert_equal "custom-secret", findings.first["RuleID"]
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Adds a new `betterleaks` formula at `1.0.1` that builds from source with a functional secret-scan JSON report test and generated shell completions.

AI-assisted: I used Codex to draft the formula and manually verified `brew install --build-from-source`, `brew test`, `brew style`, `brew linkage --test`, and `brew audit --new`.
