### PR TITLE
bun 1.3.9 (new formula, self-bootstrap attempt)

### DIFF
--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -72,7 +72,7 @@ class Bun < Formula
     if OS.linux? && Hardware::CPU.intel?
       # Keep Linux x86_64 builds off unstable AVX3/AVX512 Highway targets.
       ENV.append "CXXFLAGS",
-                 "-DHWY_DISABLED_TARGETS=HWY_AVX3+HWY_AVX3_DL+HWY_AVX3_ZEN4+HWY_AVX3_SPR"
+                 "-DHWY_DISABLED_TARGETS=HWY_AVX3+HWY_AVX3_DL+HWY_AVX3_ZEN4+HWY_AVX3_SPR+HWY_AVX10_2"
     end
     if OS.linux? && Hardware::CPU.arm?
       # GCC 12/libstdc++ marks temporary-buffer helpers deprecated and Bun treats
@@ -194,6 +194,11 @@ class Bun < Formula
       inreplace "src/bun.js/bindings/napi.cpp",
                 "new Bun::NapiModuleMeta(globalObject->m_pendingNapiModuleDlopenHandle);",
                 "new Bun::NapiModuleMeta{globalObject->m_pendingNapiModuleDlopenHandle};"
+      # AppleClang 15 cannot deduce this aggregate's template argument from
+      # designated initializers.
+      inreplace "src/bun.js/bindings/node/crypto/KeyObject.cpp",
+                "auto buf = ncrypto::Buffer {",
+                "auto buf = ncrypto::Buffer<const unsigned char> {"
     end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -66,6 +66,8 @@ class Bun < Formula
       # Bun's CMake config passes Clang-specific flags that fail with GCC.
       ENV["CC"] = Formula["llvm"].opt_bin/"clang"
       ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
+      # Highway can emit evex512 ignored-attribute warnings that become errors.
+      ENV.append "CXXFLAGS", "-Wno-ignored-attributes"
     end
 
     # Some Bun CMake sub-builds fail to auto-detect archive tools under Homebrew

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -165,6 +165,8 @@ class Bun < Formula
                 EOS
                 <<~EOS
                   struct EitherCleanupHook : std::variant<SyncCleanupHook, AsyncCleanupHook> {
+                      using std::variant<SyncCleanupHook, AsyncCleanupHook>::variant;
+
                       CleanupHook& get()
                       {
                           if (auto* sync = std::get_if<SyncCleanupHook>(this)) {

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -186,6 +186,12 @@ class Bun < Formula
                       }
                 EOS
     end
+    if OS.mac? && MacOS.version <= :sonoma
+      # AppleClang 15 rejects parenthesized aggregate init for this C-style type.
+      inreplace "src/bun.js/bindings/BunProcess.cpp",
+                "new Bun::NapiModuleMeta(globalObject->m_pendingNapiModuleDlopenHandle);",
+                "new Bun::NapiModuleMeta{globalObject->m_pendingNapiModuleDlopenHandle};"
+    end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND
     # values, which later surfaces as "CMAKE_AR-NOTFOUND: command not found".

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -272,6 +272,13 @@ class Bun < Formula
                   list(APPEND CMAKE_ARGS -DCMAKE_DSYMUTIL=${CMAKE_DSYMUTIL})
                 endif()
               EOS
+    if OS.linux? && Hardware::CPU.arm?
+      # Full LTO on Linux ARM CI can OOM at the final bun-profile link step.
+      inreplace "cmake/Options.cmake",
+                "if(RELEASE AND LINUX AND CI AND NOT ENABLE_ASSERTIONS AND NOT ENABLE_ASAN)",
+                "if(RELEASE AND LINUX AND CI AND NOT ENABLE_ASSERTIONS AND NOT ENABLE_ASAN " \
+                "AND NOT (LINUX AND ARCH STREQUAL \"aarch64\"))"
+    end
     # Newer libc++ <ranges> headers break if included after this private/public
     # shim used by Bun's V8 header wrapper.
     inreplace "src/bun.js/bindings/v8/real_v8.h",

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -72,7 +72,7 @@ class Bun < Formula
     if OS.linux? && Hardware::CPU.intel?
       # Keep Linux x86_64 builds off unstable AVX3/AVX512 Highway targets.
       ENV.append "CXXFLAGS",
-                 "-DHWY_DISABLED_TARGETS=(HWY_AVX3+HWY_AVX3_DL+HWY_AVX3_ZEN4+HWY_AVX3_SPR)"
+                 "-DHWY_DISABLED_TARGETS=HWY_AVX3+HWY_AVX3_DL+HWY_AVX3_ZEN4+HWY_AVX3_SPR"
     end
     if OS.linux? && Hardware::CPU.arm?
       # GCC 12/libstdc++ marks temporary-buffer helpers deprecated and Bun treats
@@ -140,11 +140,49 @@ class Bun < Formula
                   endif()
                 endif()
               EOS
-    if OS.mac?
-      # Newer macOS SDK headers declare this symbol without noexcept.
+    if OS.mac? && MacOS.version <= :sequoia
+      # macOS 14/15 SDK headers declare this symbol without noexcept.
       inreplace "src/bun.js/bindings/workaround-missing-symbols.cpp",
                 "void std::__libcpp_verbose_abort(char const* format, ...) noexcept",
                 "void std::__libcpp_verbose_abort(char const* format, ...)"
+    end
+    if OS.mac?
+      # macOS 14's compiler does not support deducing-this syntax in this block.
+      inreplace "src/bun.js/bindings/napi.h",
+                <<~EOS,
+                  struct EitherCleanupHook : std::variant<SyncCleanupHook, AsyncCleanupHook> {
+                      template<typename Self>
+                      auto& get(this Self& self)
+                      {
+                          using Hook = MatchConst<Self, CleanupHook>::type;
+
+                          if (auto* sync = std::get_if<SyncCleanupHook>(&self)) {
+                              return static_cast<Hook&>(*sync);
+                          }
+
+                          return static_cast<Hook&>(std::get<AsyncCleanupHook>(self));
+                      }
+                EOS
+                <<~EOS
+                  struct EitherCleanupHook : std::variant<SyncCleanupHook, AsyncCleanupHook> {
+                      CleanupHook& get()
+                      {
+                          if (auto* sync = std::get_if<SyncCleanupHook>(this)) {
+                              return static_cast<CleanupHook&>(*sync);
+                          }
+
+                          return static_cast<CleanupHook&>(std::get<AsyncCleanupHook>(*this));
+                      }
+
+                      const CleanupHook& get() const
+                      {
+                          if (auto* sync = std::get_if<SyncCleanupHook>(this)) {
+                              return static_cast<const CleanupHook&>(*sync);
+                          }
+
+                          return static_cast<const CleanupHook&>(std::get<AsyncCleanupHook>(*this));
+                      }
+                EOS
     end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -216,7 +216,7 @@ class Bun < Formula
                 "static constexpr auto humanReadableName = std::to_array(\"value\");\n")
         s.gsub!(/
           static\ constexpr\ auto\ humanReadableName\s*=\s*Bun::concatCStrings\(
-          "array of ",\s*Detail::nestedHumanReadableName<IDL>\(\)\);\s*
+          "array\ of\ ",\s*Detail::nestedHumanReadableName<IDL>\(\)\);\s*
         /mx,
                 "static constexpr auto humanReadableName = std::to_array(\"array\");\n")
         s.gsub!(/static constexpr auto humanReadableName\s*=\s*Bun::joinCStringsAsList\(Detail::nestedHumanReadableName<IDL>\(\)\.\.\.\);\s*/m,

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -272,12 +272,12 @@ class Bun < Formula
                   list(APPEND CMAKE_ARGS -DCMAKE_DSYMUTIL=${CMAKE_DSYMUTIL})
                 endif()
               EOS
-    if OS.linux? && Hardware::CPU.arm?
-      # Full LTO on Linux ARM CI can OOM at the final bun-profile link step.
+    if OS.linux?
+      # Full LTO on Linux CI can fail at the final bun-profile link step.
       inreplace "cmake/Options.cmake",
                 "if(RELEASE AND LINUX AND CI AND NOT ENABLE_ASSERTIONS AND NOT ENABLE_ASAN)",
                 "if(RELEASE AND LINUX AND CI AND NOT ENABLE_ASSERTIONS AND NOT ENABLE_ASAN " \
-                "AND NOT (LINUX AND ARCH STREQUAL \"aarch64\"))"
+                "AND NOT (LINUX AND (ARCH STREQUAL \"aarch64\" OR ARCH STREQUAL \"x86_64\")))"
     end
     # Newer libc++ <ranges> headers break if included after this private/public
     # shim used by Bun's V8 header wrapper.

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -191,6 +191,9 @@ class Bun < Formula
       inreplace "src/bun.js/bindings/BunProcess.cpp",
                 "new Bun::NapiModuleMeta(globalObject->m_pendingNapiModuleDlopenHandle);",
                 "new Bun::NapiModuleMeta{globalObject->m_pendingNapiModuleDlopenHandle};"
+      inreplace "src/bun.js/bindings/napi.cpp",
+                "new Bun::NapiModuleMeta(globalObject->m_pendingNapiModuleDlopenHandle);",
+                "new Bun::NapiModuleMeta{globalObject->m_pendingNapiModuleDlopenHandle};"
     end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -68,6 +68,11 @@ class Bun < Formula
       ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
     end
 
+    # Some Bun CMake sub-builds fail to auto-detect archive tools under Homebrew
+    # superenv and emit CMAKE_AR-NOTFOUND.
+    ENV["AR"] = "ar"
+    ENV["RANLIB"] = "ranlib"
+
     resource("bun-bootstrap").stage buildpath/"bootstrap"
     bootstrap_bin = Dir[buildpath/"bootstrap"/"**/bun"].first
     raise "bootstrap bun binary not found" if bootstrap_bin.nil?

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -155,6 +155,11 @@ class Bun < Formula
                   list(APPEND CMAKE_ARGS -DCMAKE_DSYMUTIL=${CMAKE_DSYMUTIL})
                 endif()
               EOS
+    # Newer libc++ <ranges> headers break if included after this private/public
+    # shim used by Bun's V8 header wrapper.
+    inreplace "src/bun.js/bindings/v8/real_v8.h",
+              "#define private public",
+              "#include <ranges>\n#define private public"
 
     system buildpath/"bootstrap-bin/bun", "run", "build:release"
 

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -62,6 +62,11 @@ class Bun < Formula
       ENV["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
     end
 
+    if OS.mac? && MacOS.version < :sequoia
+      # Use brewed clang on macOS 14 to avoid older Apple clang flag gaps.
+      ENV.llvm_clang
+    end
+
     if OS.linux?
       # Bun's CMake config passes Clang-specific flags that fail with GCC.
       ENV["CC"] = Formula["llvm"].opt_bin/"clang"
@@ -125,6 +130,34 @@ class Bun < Formula
                   endif()
                 endif()
               EOS
+    if OS.mac? && MacOS.version < :sequoia
+      compiler_flags = buildpath/"cmake/CompilerFlags.cmake"
+      if compiler_flags.exist? && compiler_flags.read.include?("-Wno-c23-extensions")
+        inreplace "cmake/CompilerFlags.cmake",
+                  "-Wno-c23-extensions",
+                  "-Wno-c2x-extensions",
+                  global: true
+      end
+      buildbun_cmake = buildpath/"cmake/targets/BuildBun.cmake"
+      if buildbun_cmake.read.include?("-Wno-c23-extensions")
+        inreplace "cmake/targets/BuildBun.cmake",
+                  "-Wno-c23-extensions",
+                  "-Wno-c2x-extensions",
+                  global: true
+      end
+      if buildbun_cmake.read.include?("-Wno-c++23-lambda-attributes")
+        inreplace "cmake/targets/BuildBun.cmake",
+                  "-Wno-c++23-lambda-attributes",
+                  "",
+                  global: true
+      end
+      if buildbun_cmake.read.include?("-Wno-dangling-assignment-gsl")
+        inreplace "cmake/targets/BuildBun.cmake",
+                  "-Wno-dangling-assignment-gsl",
+                  "-Wno-dangling-gsl",
+                  global: true
+      end
+    end
     # Highway AVX3/AVX512 target variants can fail to compile on Linux x86_64
     # CI runners; disable those targets to keep baseline/x86-64 builds stable.
     inreplace "cmake/targets/BuildHighway.cmake",

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -282,7 +282,8 @@ class Bun < Formula
       inreplace "cmake/Options.cmake",
                 "if(RELEASE AND LINUX AND CI AND NOT ENABLE_ASSERTIONS AND NOT ENABLE_ASAN)",
                 "if(RELEASE AND LINUX AND CI AND NOT ENABLE_ASSERTIONS AND NOT ENABLE_ASAN " \
-                "AND NOT (LINUX AND (ARCH STREQUAL \"aarch64\" OR ARCH STREQUAL \"x86_64\")))"
+                "AND NOT (LINUX AND (ARCH STREQUAL \"aarch64\" OR ARCH STREQUAL \"arm64\" " \
+                "OR ARCH STREQUAL \"x86_64\" OR ARCH STREQUAL \"x64\")))"
     end
     # Newer libc++ <ranges> headers break if included after this private/public
     # shim used by Bun's V8 header wrapper.

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -62,11 +62,6 @@ class Bun < Formula
       ENV["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
     end
 
-    if OS.mac? && MacOS.version < :sequoia
-      # Use brewed clang on macOS 14 to avoid older Apple clang flag gaps.
-      ENV.llvm_clang
-    end
-
     if OS.linux?
       # Bun's CMake config passes Clang-specific flags that fail with GCC.
       ENV["CC"] = Formula["llvm"].opt_bin/"clang"
@@ -130,34 +125,6 @@ class Bun < Formula
                   endif()
                 endif()
               EOS
-    if OS.mac? && MacOS.version < :sequoia
-      compiler_flags = buildpath/"cmake/CompilerFlags.cmake"
-      if compiler_flags.exist? && compiler_flags.read.include?("-Wno-c23-extensions")
-        inreplace "cmake/CompilerFlags.cmake",
-                  "-Wno-c23-extensions",
-                  "-Wno-c2x-extensions",
-                  global: true
-      end
-      buildbun_cmake = buildpath/"cmake/targets/BuildBun.cmake"
-      if buildbun_cmake.read.include?("-Wno-c23-extensions")
-        inreplace "cmake/targets/BuildBun.cmake",
-                  "-Wno-c23-extensions",
-                  "-Wno-c2x-extensions",
-                  global: true
-      end
-      if buildbun_cmake.read.include?("-Wno-c++23-lambda-attributes")
-        inreplace "cmake/targets/BuildBun.cmake",
-                  "-Wno-c++23-lambda-attributes",
-                  "",
-                  global: true
-      end
-      if buildbun_cmake.read.include?("-Wno-dangling-assignment-gsl")
-        inreplace "cmake/targets/BuildBun.cmake",
-                  "-Wno-dangling-assignment-gsl",
-                  "-Wno-dangling-gsl",
-                  global: true
-      end
-    end
     # Highway AVX3/AVX512 target variants can fail to compile on Linux x86_64
     # CI runners; disable those targets to keep baseline/x86-64 builds stable.
     inreplace "cmake/targets/BuildHighway.cmake",

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -82,14 +82,54 @@ class Bun < Formula
     chmod 0755, buildpath/"bootstrap-bin/bun"
     ENV.prepend_path "PATH", buildpath/"bootstrap-bin"
 
-    # Avoid -Wundefined-var-template failures with current toolchains.
-    ENV.append "CXXFLAGS", "-Wno-undefined-var-template"
+    # Avoid warning-option portability breakages under newer AppleClang/GCC.
+    ENV.append "CFLAGS", "-Wno-unknown-warning-option"
+    ENV.append "CXXFLAGS", "-Wno-undefined-var-template -Wno-unknown-warning-option"
 
     # Bun 1.3.9 defines this dSYM post-build hook with no explicit SOURCES.
     # register_command rejects that, so wire the built bun binary as a source.
     inreplace "cmake/targets/BuildBun.cmake",
               "      TARGET\n        ${bun}\n      TARGET_PHASE\n",
               "      TARGET\n        ${bun}\n      SOURCES\n        ${BUILD_PATH}/${bun}\n      TARGET_PHASE\n"
+    # Apple strip lacks Bun's GNU-style options in this block.
+    inreplace "cmake/targets/BuildBun.cmake",
+              "    set(CMAKE_STRIP_FLAGS --remove-section=__TEXT,__eh_frame " \
+              "--remove-section=__TEXT,__unwind_info " \
+              "--remove-section=__TEXT,__gcc_except_tab)\n",
+              "    set(CMAKE_STRIP_FLAGS)\n"
+    inreplace "cmake/targets/BuildBun.cmake",
+              "          --strip-all\n          --strip-debug\n          --discard-all\n",
+              ""
+
+    # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND
+    # values, which later surfaces as "CMAKE_AR-NOTFOUND: command not found".
+    inreplace "cmake/tools/SetupLLVM.cmake",
+              "  find_llvm_command(CMAKE_AR llvm-ar)\n",
+              <<~EOS
+                find_llvm_command(CMAKE_AR llvm-ar)
+                if(CMAKE_AR MATCHES "NOTFOUND")
+                  find_command(VARIABLE CMAKE_AR COMMAND ar REQUIRED ON)
+                  list(APPEND CMAKE_ARGS -DCMAKE_AR=${CMAKE_AR})
+                endif()
+              EOS
+    inreplace "cmake/tools/SetupLLVM.cmake",
+              "  find_llvm_command(CMAKE_RANLIB llvm-ranlib)\n",
+              <<~EOS
+                find_llvm_command(CMAKE_RANLIB llvm-ranlib)
+                if(CMAKE_RANLIB MATCHES "NOTFOUND")
+                  find_command(VARIABLE CMAKE_RANLIB COMMAND ranlib REQUIRED ON)
+                  list(APPEND CMAKE_ARGS -DCMAKE_RANLIB=${CMAKE_RANLIB})
+                endif()
+              EOS
+    inreplace "cmake/tools/SetupLLVM.cmake",
+              "    find_llvm_command(CMAKE_DSYMUTIL dsymutil)\n",
+              <<~EOS
+                find_llvm_command(CMAKE_DSYMUTIL dsymutil)
+                if(CMAKE_DSYMUTIL MATCHES "NOTFOUND")
+                  find_command(VARIABLE CMAKE_DSYMUTIL COMMAND dsymutil REQUIRED ON)
+                  list(APPEND CMAKE_ARGS -DCMAKE_DSYMUTIL=${CMAKE_DSYMUTIL})
+                endif()
+              EOS
 
     system "bun", "run", "build:release"
 

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -140,6 +140,17 @@ class Bun < Formula
                   endif()
                 endif()
               EOS
+    # WebKit autobuild artifacts can contain this typo in JSArrayInlines.h.
+    inreplace "cmake/tools/SetupWebKit.cmake",
+              "file(RENAME ${CACHE_PATH}/bun-webkit ${WEBKIT_PATH})\n",
+              <<~EOS
+                file(RENAME ${CACHE_PATH}/bun-webkit ${WEBKIT_PATH})
+                if(EXISTS ${WEBKIT_INCLUDE_PATH}/JavaScriptCore/JSArrayInlines.h)
+                  file(READ ${WEBKIT_INCLUDE_PATH}/JavaScriptCore/JSArrayInlines.h JSARRAYINLINES_CONTENT)
+                  string(REPLACE "DirectArgumeLts" "DirectArguments" JSARRAYINLINES_CONTENT "${JSARRAYINLINES_CONTENT}")
+                  file(WRITE ${WEBKIT_INCLUDE_PATH}/JavaScriptCore/JSArrayInlines.h "${JSARRAYINLINES_CONTENT}")
+                endif()
+              EOS
     if OS.mac? && MacOS.version <= :sequoia
       # macOS 14/15 SDK headers declare this symbol without noexcept.
       inreplace "src/bun.js/bindings/workaround-missing-symbols.cpp",

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -125,20 +125,14 @@ class Bun < Formula
                   endif()
                 endif()
               EOS
-    # Highway AVX3/AVX512 target variants can fail to compile on Linux x86_64
-    # CI runners; disable those targets to keep baseline/x86-64 builds stable.
-    inreplace "cmake/targets/BuildHighway.cmake",
-              "endif()\n",
-              <<~EOS
-                endif()
-
-                if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
-                  list(APPEND HIGHWAY_CMAKE_ARGS
-                    -DCMAKE_C_FLAGS=-DHWY_DISABLED_TARGETS=(HWY_AVX3|HWY_AVX3_DL|HWY_AVX3_ZEN4|HWY_AVX3_SPR)
-                    -DCMAKE_CXX_FLAGS=-DHWY_DISABLED_TARGETS=(HWY_AVX3|HWY_AVX3_DL|HWY_AVX3_ZEN4|HWY_AVX3_SPR)
-                  )
-                endif()
-              EOS
+    if OS.linux? && Hardware::CPU.intel?
+      # Keep Linux x86_64 builds off unstable AVX3/AVX512 Highway targets.
+      inreplace "src/bun.js/bindings/highway_strings.cpp",
+                "#include <hwy/foreach_target.h> // Must come before highway.h",
+                "#define HWY_DISABLED_TARGETS " \
+                "(HWY_AVX3 | HWY_AVX3_DL | HWY_AVX3_ZEN4 | HWY_AVX3_SPR)\n" \
+                "#include <hwy/foreach_target.h> // Must come before highway.h"
+    end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND
     # values, which later surfaces as "CMAKE_AR-NOTFOUND: command not found".

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -125,6 +125,20 @@ class Bun < Formula
                   endif()
                 endif()
               EOS
+    # Highway AVX3/AVX512 target variants can fail to compile on Linux x86_64
+    # CI runners; disable those targets to keep baseline/x86-64 builds stable.
+    inreplace "cmake/targets/BuildHighway.cmake",
+              "endif()\n",
+              <<~EOS
+                endif()
+
+                if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+                  list(APPEND HIGHWAY_CMAKE_ARGS
+                    -DCMAKE_C_FLAGS=-DHWY_DISABLED_TARGETS=(HWY_AVX3|HWY_AVX3_DL|HWY_AVX3_ZEN4|HWY_AVX3_SPR)
+                    -DCMAKE_CXX_FLAGS=-DHWY_DISABLED_TARGETS=(HWY_AVX3|HWY_AVX3_DL|HWY_AVX3_ZEN4|HWY_AVX3_SPR)
+                  )
+                endif()
+              EOS
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND
     # values, which later surfaces as "CMAKE_AR-NOTFOUND: command not found".

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -199,6 +199,10 @@ class Bun < Formula
       inreplace "src/bun.js/bindings/node/crypto/KeyObject.cpp",
                 "auto buf = ncrypto::Buffer {",
                 "auto buf = ncrypto::Buffer<const unsigned char> {"
+      # AppleClang 15 doesn't apply CWG2518; keep this assertion dependent.
+      inreplace "src/vm/SigintWatcher.h",
+                "static_assert(false, \"Invalid held type\");",
+                "static_assert(sizeof(T) == 0, \"Invalid held type\");"
     end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -62,6 +62,12 @@ class Bun < Formula
       ENV["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
     end
 
+    if OS.linux?
+      # Bun's CMake config passes Clang-specific flags that fail with GCC.
+      ENV["CC"] = Formula["llvm"].opt_bin/"clang"
+      ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
+    end
+
     resource("bun-bootstrap").stage buildpath/"bootstrap"
     bootstrap_bin = Dir[buildpath/"bootstrap"/"**/bun"].first
     raise "bootstrap bun binary not found" if bootstrap_bin.nil?

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -74,7 +74,7 @@ class Bun < Formula
       ENV.append "CXXFLAGS",
                  "-DHWY_DISABLED_TARGETS=HWY_AVX3+HWY_AVX3_DL+HWY_AVX3_ZEN4+HWY_AVX3_SPR+HWY_AVX10_2"
     end
-    if OS.linux? && Hardware::CPU.arm?
+    if OS.linux?
       # GCC 12/libstdc++ marks temporary-buffer helpers deprecated and Bun treats
       # warnings as errors in TextCodecCJK.
       ENV.append "CXXFLAGS", "-Wno-error=deprecated-declarations"

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -203,6 +203,44 @@ class Bun < Formula
       inreplace "src/vm/SigintWatcher.h",
                 "static_assert(false, \"Invalid held type\");",
                 "static_assert(sizeof(T) == 0, \"Invalid held type\");"
+      # AppleClang 15 rejects several consteval string builders in this helper.
+      # These names are for diagnostics only, so keep simpler literals on Sonoma.
+      inreplace "src/bun.js/bindings/BunIDLHumanReadable.h",
+                <<~EOS,
+                  static constexpr auto humanReadableName = Bun::concatCStrings(
+                      Detail::nestedHumanReadableName<IDL>(),
+                      Detail::separatorForHumanReadableBinaryDisjunction<IDL>(),
+                      "null");
+                EOS
+                <<~EOS
+                  static constexpr auto humanReadableName = std::to_array("value");
+                EOS
+      inreplace "src/bun.js/bindings/BunIDLHumanReadable.h",
+                <<~EOS,
+                  static constexpr auto humanReadableName = Bun::concatCStrings(
+                      Detail::nestedHumanReadableName<IDL>(),
+                      Detail::separatorForHumanReadableBinaryDisjunction<IDL>(),
+                      "undefined");
+                EOS
+                <<~EOS
+                  static constexpr auto humanReadableName = std::to_array("value");
+                EOS
+      inreplace "src/bun.js/bindings/BunIDLHumanReadable.h",
+                <<~EOS,
+                  static constexpr auto humanReadableName
+                      = Bun::concatCStrings("array of ", Detail::nestedHumanReadableName<IDL>());
+                EOS
+                <<~EOS
+                  static constexpr auto humanReadableName = std::to_array("array");
+                EOS
+      inreplace "src/bun.js/bindings/BunIDLHumanReadable.h",
+                <<~EOS,
+                  static constexpr auto humanReadableName
+                      = Bun::joinCStringsAsList(Detail::nestedHumanReadableName<IDL>()...);
+                EOS
+                <<~EOS
+                  static constexpr auto humanReadableName = std::to_array("value");
+                EOS
     end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -102,6 +102,29 @@ class Bun < Formula
     inreplace "cmake/targets/BuildBun.cmake",
               "          --strip-all\n          --strip-debug\n          --discard-all\n",
               ""
+    # Older Apple clang rejects this zlib workaround flag as unknown.
+    # Keep it only when the current compiler supports it.
+    inreplace "cmake/targets/BuildZlib.cmake",
+              <<~EOS,
+                if(APPLE)
+                  set(ZLIB_CMAKE_C_FLAGS "-fno-define-target-os-macros")
+                  set(ZLIB_CMAKE_CXX_FLAGS "-fno-define-target-os-macros")
+                endif()
+              EOS
+              <<~EOS
+                if(APPLE)
+                  include(CheckCCompilerFlag)
+                  include(CheckCXXCompilerFlag)
+                  check_c_compiler_flag("-fno-define-target-os-macros" ZLIB_HAS_NO_DEFINE_TARGET_OS_MACROS_C)
+                  check_cxx_compiler_flag("-fno-define-target-os-macros" ZLIB_HAS_NO_DEFINE_TARGET_OS_MACROS_CXX)
+                  if(ZLIB_HAS_NO_DEFINE_TARGET_OS_MACROS_C)
+                    set(ZLIB_CMAKE_C_FLAGS "-fno-define-target-os-macros")
+                  endif()
+                  if(ZLIB_HAS_NO_DEFINE_TARGET_OS_MACROS_CXX)
+                    set(ZLIB_CMAKE_CXX_FLAGS "-fno-define-target-os-macros")
+                  endif()
+                endif()
+              EOS
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND
     # values, which later surfaces as "CMAKE_AR-NOTFOUND: command not found".
@@ -133,7 +156,7 @@ class Bun < Formula
                 endif()
               EOS
 
-    system "bun", "run", "build:release"
+    system buildpath/"bootstrap-bin/bun", "run", "build:release"
 
     bin.install "build/release/bun"
     bin.install_symlink bin/"bun" => "bunx"

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -245,6 +245,14 @@ class Bun < Formula
                 endif()
               EOS
     inreplace "cmake/tools/SetupLLVM.cmake",
+              "    find_llvm_command(LLD_PROGRAM ld.lld)\n",
+              <<~EOS
+                find_llvm_command(LLD_PROGRAM ld.lld)
+                if(LLD_PROGRAM MATCHES "NOTFOUND")
+                  find_command(VARIABLE LLD_PROGRAM COMMAND ld.lld REQUIRED ON)
+                endif()
+              EOS
+    inreplace "cmake/tools/SetupLLVM.cmake",
               "    find_llvm_command(CMAKE_DSYMUTIL dsymutil)\n",
               <<~EOS
                 find_llvm_command(CMAKE_DSYMUTIL dsymutil)

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -57,9 +57,14 @@ class Bun < Formula
 
   def install
     if OS.linux? && ENV["CI"]
-      # Linux CI runners are prone to OOM with default parallel build settings.
-      ENV.deparallelize
-      ENV["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
+      # Linux ARM CI runners are prone to OOM with default parallel build settings.
+      if Hardware::CPU.arm?
+        ENV.deparallelize
+        ENV["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
+      else
+        # Keep some parallelism on Linux x86_64 to avoid CI timeouts.
+        ENV["CMAKE_BUILD_PARALLEL_LEVEL"] = "2"
+      end
     end
 
     if OS.linux?

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -205,42 +205,23 @@ class Bun < Formula
                 "static_assert(sizeof(T) == 0, \"Invalid held type\");"
       # AppleClang 15 rejects several consteval string builders in this helper.
       # These names are for diagnostics only, so keep simpler literals on Sonoma.
-      inreplace "src/bun.js/bindings/BunIDLHumanReadable.h",
-                <<~EOS,
-                  static constexpr auto humanReadableName = Bun::concatCStrings(
-                      Detail::nestedHumanReadableName<IDL>(),
-                      Detail::separatorForHumanReadableBinaryDisjunction<IDL>(),
-                      "null");
-                EOS
-                <<~EOS
-                  static constexpr auto humanReadableName = std::to_array("value");
-                EOS
-      inreplace "src/bun.js/bindings/BunIDLHumanReadable.h",
-                <<~EOS,
-                  static constexpr auto humanReadableName = Bun::concatCStrings(
-                      Detail::nestedHumanReadableName<IDL>(),
-                      Detail::separatorForHumanReadableBinaryDisjunction<IDL>(),
-                      "undefined");
-                EOS
-                <<~EOS
-                  static constexpr auto humanReadableName = std::to_array("value");
-                EOS
-      inreplace "src/bun.js/bindings/BunIDLHumanReadable.h",
-                <<~EOS,
-                  static constexpr auto humanReadableName
-                      = Bun::concatCStrings("array of ", Detail::nestedHumanReadableName<IDL>());
-                EOS
-                <<~EOS
-                  static constexpr auto humanReadableName = std::to_array("array");
-                EOS
-      inreplace "src/bun.js/bindings/BunIDLHumanReadable.h",
-                <<~EOS,
-                  static constexpr auto humanReadableName
-                      = Bun::joinCStringsAsList(Detail::nestedHumanReadableName<IDL>()...);
-                EOS
-                <<~EOS
-                  static constexpr auto humanReadableName = std::to_array("value");
-                EOS
+      inreplace "src/bun.js/bindings/BunIDLHumanReadable.h" do |s|
+        s.gsub!(/
+          static\ constexpr\ auto\ humanReadableName\ =\ Bun::concatCStrings\(
+          \s*Detail::nestedHumanReadableName<IDL>\(\),
+          \s*Detail::separatorForHumanReadableBinaryDisjunction<IDL>\(\),
+          \s*"(?:null|undefined)"\);
+          \s*
+        /mx,
+                "static constexpr auto humanReadableName = std::to_array(\"value\");\n")
+        s.gsub!(/
+          static\ constexpr\ auto\ humanReadableName\s*=\s*Bun::concatCStrings\(
+          "array of ",\s*Detail::nestedHumanReadableName<IDL>\(\)\);\s*
+        /mx,
+                "static constexpr auto humanReadableName = std::to_array(\"array\");\n")
+        s.gsub!(/static constexpr auto humanReadableName\s*=\s*Bun::joinCStringsAsList\(Detail::nestedHumanReadableName<IDL>\(\)\.\.\.\);\s*/m,
+                "static constexpr auto humanReadableName = std::to_array(\"value\");\n")
+      end
     end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -74,11 +74,11 @@ class Bun < Formula
     # Avoid -Wundefined-var-template failures with current toolchains.
     ENV.append "CXXFLAGS", "-Wno-undefined-var-template"
 
-    # Bun 1.3.9 can invoke this block with an empty target on macOS during
-    # configure, which trips register_command validation.
+    # Bun 1.3.9 defines this dSYM post-build hook with no explicit SOURCES.
+    # register_command rejects that, so wire the built bun binary as a source.
     inreplace "cmake/targets/BuildBun.cmake",
-              "if(CMAKE_HOST_APPLE AND bunStrip)",
-              "if(CMAKE_HOST_APPLE AND bunStrip AND NOT \"${bun}\" STREQUAL \"\")"
+              "      TARGET\n        ${bun}\n      TARGET_PHASE\n",
+              "      TARGET\n        ${bun}\n      SOURCES\n        ${BUILD_PATH}/${bun}\n      TARGET_PHASE\n"
 
     system "bun", "run", "build:release"
 

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -69,6 +69,11 @@ class Bun < Formula
       # Highway can emit evex512 ignored-attribute warnings that become errors.
       ENV.append "CXXFLAGS", "-Wno-ignored-attributes"
     end
+    if OS.linux? && Hardware::CPU.arm?
+      # GCC 12/libstdc++ marks temporary-buffer helpers deprecated and Bun treats
+      # warnings as errors in TextCodecCJK.
+      ENV.append "CXXFLAGS", "-Wno-error=deprecated-declarations"
+    end
 
     # Some Bun CMake sub-builds fail to auto-detect archive tools under Homebrew
     # superenv and emit CMAKE_AR-NOTFOUND.
@@ -128,10 +133,10 @@ class Bun < Formula
     if OS.linux? && Hardware::CPU.intel?
       # Keep Linux x86_64 builds off unstable AVX3/AVX512 Highway targets.
       inreplace "src/bun.js/bindings/highway_strings.cpp",
-                "#include <hwy/foreach_target.h> // Must come before highway.h",
-                "#define HWY_DISABLED_TARGETS " \
+                "// Must be first\n#include \"root.h\"\n",
+                "// Must be first\n#define HWY_DISABLED_TARGETS " \
                 "(HWY_AVX3 | HWY_AVX3_DL | HWY_AVX3_ZEN4 | HWY_AVX3_SPR)\n" \
-                "#include <hwy/foreach_target.h> // Must come before highway.h"
+                "#include \"root.h\"\n"
     end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -1,0 +1,102 @@
+class Bun < Formula
+  desc "Incredibly fast JavaScript runtime, bundler, test runner, and package manager"
+  homepage "https://bun.com"
+  url "https://github.com/oven-sh/bun.git",
+      tag:      "bun-v1.3.9",
+      revision: "cf6cdbbbadd50604bc17f21ed5d0612c920a5d9a"
+  license all_of: [
+    "MIT",          # Bun itself and most dependencies
+    "Apache-2.0",   # boringssl, simdutf, uSockets, and others
+    "BSD-3-Clause", # boringssl, lol-html
+    "BSD-2-Clause", # libbase64
+    "Zlib",         # zlib
+  ]
+  head "https://github.com/oven-sh/bun.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :build
+  depends_on "python@3.12" => :build
+  depends_on "rust" => :build
+
+  on_macos do
+    on_sonoma :or_older do
+      depends_on "llvm" => :build
+    end
+  end
+
+  on_linux do
+    depends_on "lld" => :build
+    depends_on "llvm" => :build
+  end
+
+  # Use the official release binary only as a bootstrap compiler for
+  # building Bun from source.
+  resource "bun-bootstrap" do
+    on_macos do
+      on_arm do
+        url "https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-darwin-aarch64.zip"
+        sha256 "cde6a4edf19cf64909158fa5a464a12026fd7f0d79a4a950c10cf0af04266d85"
+      end
+      on_intel do
+        url "https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-darwin-x64.zip"
+        sha256 "588f4a48740b9a0c366a00f878810ab3ab5e6734d29b7c3cbdd9484b74a007de"
+      end
+    end
+    on_linux do
+      on_arm do
+        url "https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-linux-aarch64.zip"
+        sha256 "a2c2862bcc1fd1c0b3a8dcdc8c7efb5e2acd871eb20ed2f17617884ede81c844"
+      end
+      on_intel do
+        url "https://github.com/oven-sh/bun/releases/download/bun-v1.3.9/bun-linux-x64.zip"
+        sha256 "4680e80e44e32aa718560ceae85d22ecfbf2efb8f3641782e35e4b7efd65a1aa"
+      end
+    end
+  end
+
+  def install
+    if OS.linux? && ENV["CI"]
+      # Linux CI runners are prone to OOM with default parallel build settings.
+      ENV.deparallelize
+      ENV["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
+    end
+
+    resource("bun-bootstrap").stage buildpath/"bootstrap"
+    bootstrap_bin = Dir[buildpath/"bootstrap"/"**/bun"].first
+    raise "bootstrap bun binary not found" if bootstrap_bin.nil?
+
+    (buildpath/"bootstrap-bin").mkpath
+    cp bootstrap_bin, buildpath/"bootstrap-bin/bun"
+    chmod 0755, buildpath/"bootstrap-bin/bun"
+    ENV.prepend_path "PATH", buildpath/"bootstrap-bin"
+
+    # Avoid -Wundefined-var-template failures with current toolchains.
+    ENV.append "CXXFLAGS", "-Wno-undefined-var-template"
+
+    # Bun 1.3.9 can invoke this block with an empty target on macOS during
+    # configure, which trips register_command validation.
+    inreplace "cmake/targets/BuildBun.cmake",
+              "if(CMAKE_HOST_APPLE AND bunStrip)",
+              "if(CMAKE_HOST_APPLE AND bunStrip AND NOT \"${bun}\" STREQUAL \"\")"
+
+    system "bun", "run", "build:release"
+
+    bin.install "build/release/bun"
+    bin.install_symlink bin/"bun" => "bunx"
+
+    bash_completion.install "completions/bun.bash" => "bun"
+    zsh_completion.install "completions/bun.zsh" => "_bun"
+    fish_completion.install "completions/bun.fish"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/bun --version")
+
+    (testpath/"hello.ts").write <<~TYPESCRIPT
+      console.log("Hello world!");
+    TYPESCRIPT
+
+    assert_equal "Hello world!", shell_output("#{bin}/bun run hello.ts").chomp
+  end
+end

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -69,10 +69,20 @@ class Bun < Formula
       # Highway can emit evex512 ignored-attribute warnings that become errors.
       ENV.append "CXXFLAGS", "-Wno-ignored-attributes"
     end
+    if OS.linux? && Hardware::CPU.intel?
+      # Keep Linux x86_64 builds off unstable AVX3/AVX512 Highway targets.
+      ENV.append "CXXFLAGS",
+                 "-DHWY_DISABLED_TARGETS=(HWY_AVX3+HWY_AVX3_DL+HWY_AVX3_ZEN4+HWY_AVX3_SPR)"
+    end
     if OS.linux? && Hardware::CPU.arm?
       # GCC 12/libstdc++ marks temporary-buffer helpers deprecated and Bun treats
       # warnings as errors in TextCodecCJK.
       ENV.append "CXXFLAGS", "-Wno-error=deprecated-declarations"
+    end
+    if OS.mac? && MacOS.version <= :sonoma
+      # AppleClang on macOS 14 treats unnamed parameters in C stubs as C2x
+      # extension warnings, and Bun builds with -Werror.
+      ENV.append "CFLAGS", "-Wno-error=c2x-extensions"
     end
 
     # Some Bun CMake sub-builds fail to auto-detect archive tools under Homebrew
@@ -130,13 +140,11 @@ class Bun < Formula
                   endif()
                 endif()
               EOS
-    if OS.linux? && Hardware::CPU.intel?
-      # Keep Linux x86_64 builds off unstable AVX3/AVX512 Highway targets.
-      inreplace "src/bun.js/bindings/highway_strings.cpp",
-                "// Must be first\n#include \"root.h\"\n",
-                "// Must be first\n#define HWY_DISABLED_TARGETS " \
-                "(HWY_AVX3 | HWY_AVX3_DL | HWY_AVX3_ZEN4 | HWY_AVX3_SPR)\n" \
-                "#include \"root.h\"\n"
+    if OS.mac?
+      # Newer macOS SDK headers declare this symbol without noexcept.
+      inreplace "src/bun.js/bindings/workaround-missing-symbols.cpp",
+                "void std::__libcpp_verbose_abort(char const* format, ...) noexcept",
+                "void std::__libcpp_verbose_abort(char const* format, ...)"
     end
 
     # Bun's SetupLLVM helper can append CMAKE_AR/CMAKE_RANLIB with NOTFOUND


### PR DESCRIPTION
Built and audited locally on macOS.

Alternative `bun 1.3.9` formula attempt using self-bootstrap (minimal patching) to reduce the dependency/patch surface while we compare behavior against the larger CMake-patch approach.
