### PR TITLE
surge 0.6.10 (new formula)

### DIFF
--- a/Formula/s/surge.rb
+++ b/Formula/s/surge.rb
@@ -1,0 +1,33 @@
+class Surge < Formula
+  desc "Blazing fast TUI download manager"
+  homepage "https://github.com/surge-downloader/Surge"
+  url "https://github.com/surge-downloader/Surge/archive/refs/tags/v0.6.10.tar.gz"
+  sha256 "3cfb3cc68d360f370863f4d487b56ef56f920a3add0fb9d35da1ab3303a8d947"
+  license "MIT"
+  head "https://github.com/surge-downloader/Surge.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/surge-downloader/surge/cmd.Version=#{version}
+      -X github.com/surge-downloader/surge/cmd.BuildTime=homebrew
+    ]
+
+    system "go", "build", *std_go_args(ldflags:, output: bin/"surge"), "."
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/surge --version")
+
+    ENV["XDG_CONFIG_HOME"] = testpath/".config"
+    ENV["XDG_STATE_HOME"] = testpath/".local/state"
+    ENV["XDG_RUNTIME_DIR"] = testpath/".runtime"
+
+    token = shell_output("#{bin}/surge token").strip
+    assert_match(/\A[0-9a-f-]{36}\z/, token)
+
+    assert_path_exists testpath/".local/state/surge/token" if OS.linux?
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.
