### PR TITLE
cloudflare-speed-cli 0.6.5 (new formula)

### DIFF
--- a/Formula/c/cloudflare-speed-cli.rb
+++ b/Formula/c/cloudflare-speed-cli.rb
@@ -1,0 +1,21 @@
+class CloudflareSpeedCli < Formula
+  desc "Cloudflare-based speed test with optional TUI"
+  homepage "https://github.com/kavehtehrani/cloudflare-speed-cli"
+  url "https://github.com/kavehtehrani/cloudflare-speed-cli/archive/refs/tags/v0.6.5.tar.gz"
+  sha256 "d259b81f2641613192ef00612a58a817e3cb04e83ee56f8e2052d70cf403bf7f"
+  license "GPL-3.0-only"
+  head "https://github.com/kavehtehrani/cloudflare-speed-cli.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: ".")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/cloudflare-speed-cli --version")
+
+    output = shell_output("#{bin}/cloudflare-speed-cli --silent 2>&1", 1)
+    assert_match "--silent can only be used with --json", output
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.
