### PR TITLE
sidecar 0.77.0 (new formula)

### DIFF
--- a/Formula/s/sidecar.rb
+++ b/Formula/s/sidecar.rb
@@ -1,0 +1,22 @@
+class Sidecar < Formula
+  desc "Terminal UI for diffs, file trees, conversation history, and tasks"
+  homepage "https://github.com/marcus/sidecar"
+  url "https://github.com/marcus/sidecar/archive/refs/tags/v0.77.0.tar.gz"
+  sha256 "5f27ab886cae95a3b2681a0d376528ccaf07cb0c129ae5c749557f2eafa7effb"
+  license "MIT"
+  head "https://github.com/marcus/sidecar.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.Version=#{version}"
+
+    system "go", "build", *std_go_args(ldflags:, output: bin/"sidecar"), "./cmd/sidecar"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/sidecar --version")
+    assert_match "sidecar requires an interactive terminal",
+                 shell_output("#{bin}/sidecar --project #{testpath} 2>&1", 1)
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.
