### PR TITLE
oyo: add revision for bottles

### DIFF
--- a/Formula/o/oyo.rb
+++ b/Formula/o/oyo.rb
@@ -4,6 +4,7 @@ class Oyo < Formula
   url "https://github.com/ahkohd/oyo/archive/refs/tags/v0.1.24.tar.gz"
   sha256 "5283d39438fa71e25a096ade1c755ca80f3eb3f2adbadd7b56936e1e83f3f197"
   license "MIT"
+  revision 1
   head "https://github.com/ahkohd/oyo.git", branch: "main"
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Audit/style checked locally on macOS.

No functional change.

Add revision so this recently merged formula goes through pr-pull and gets BrewTestBot bottle commits on main.
