### PR TITLE
jolt: reorder service block

### DIFF
--- a/Formula/j/jolt.rb
+++ b/Formula/j/jolt.rb
@@ -18,13 +18,13 @@ class Jolt < Formula
 
   depends_on "rust" => :build
 
+  def install
+    system "cargo", "install", *std_cargo_args(path: "cli")
+  end
+
   service do
     run [opt_bin/"jolt", "daemon", "start", "--foreground"]
     keep_alive true
-  end
-
-  def install
-    system "cargo", "install", *std_cargo_args(path: "cli")
   end
 
   test do


### PR DESCRIPTION
Built and validated locally with `brew style` and `brew audit --strict`.

Syntax-only change: move `service do` after `def install` and before `test do`.
