### PR TITLE
jiq: use bare std_cargo_args

### DIFF
--- a/Formula/j/jiq.rb
+++ b/Formula/j/jiq.rb
@@ -8,7 +8,7 @@ class Jiq < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args(path: ".")
+    system "cargo", "install", *std_cargo_args
   end
 
   test do


### PR DESCRIPTION
Built and validated locally with `brew style` and `brew audit --strict`.

Syntax-only change: replace `*std_cargo_args(path: ".")` with bare `*std_cargo_args`.
