### PR TITLE
datui: use bare std_cargo_args

### DIFF
--- a/Formula/d/datui.rb
+++ b/Formula/d/datui.rb
@@ -10,7 +10,7 @@ class Datui < Formula
   depends_on "fontconfig"
 
   def install
-    system "cargo", "install", "--bin", "datui", *std_cargo_args(path: ".")
+    system "cargo", "install", "--bin", "datui", *std_cargo_args
   end
 
   test do


### PR DESCRIPTION
Built and validated locally with `brew style` and `brew audit --strict`.

Syntax-only change: replace `*std_cargo_args(path: ".")` with bare `*std_cargo_args`.
