### PR TITLE
models: use bare std_cargo_args

### DIFF
--- a/Formula/m/models.rb
+++ b/Formula/m/models.rb
@@ -9,7 +9,7 @@ class Models < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args(path: ".")
+    system "cargo", "install", *std_cargo_args
     bin.install_symlink bin/"models" => "agents"
   end
 


### PR DESCRIPTION
Built and validated locally with `brew style` and `brew audit --strict`.

Syntax-only change: replace `*std_cargo_args(path: ".")` with bare `*std_cargo_args`.
