### PR TITLE
vortix: use bare std_cargo_args

### DIFF
--- a/Formula/v/vortix.rb
+++ b/Formula/v/vortix.rb
@@ -21,7 +21,7 @@ class Vortix < Formula
   depends_on "wireguard-tools"
 
   def install
-    system "cargo", "install", *std_cargo_args(path: ".")
+    system "cargo", "install", *std_cargo_args
   end
 
   test do


### PR DESCRIPTION
Built and validated locally with `brew style` and `brew audit --strict`.

Syntax-only change: replace `*std_cargo_args(path: ".")` with bare `*std_cargo_args`.
