### PR TITLE
cloudflare-speed-cli: use bare std_cargo_args

### DIFF
--- a/Formula/c/cloudflare-speed-cli.rb
+++ b/Formula/c/cloudflare-speed-cli.rb
@@ -9,7 +9,7 @@ class CloudflareSpeedCli < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args(path: ".")
+    system "cargo", "install", *std_cargo_args
   end
 
   test do


### PR DESCRIPTION
Built and validated locally with `brew style` and `brew audit --strict`.

Syntax-only change: replace `*std_cargo_args(path: ".")` with bare `*std_cargo_args`.
