### PR TITLE
tredis: use bare std_cargo_args

### DIFF
--- a/Formula/t/tredis.rb
+++ b/Formula/t/tredis.rb
@@ -16,7 +16,7 @@ class Tredis < Formula
     ENV["OPENSSL_INCLUDE_DIR"] = openssl.opt_include
     ENV.prepend_path "PKG_CONFIG_PATH", openssl.opt_lib/"pkgconfig"
 
-    system "cargo", "install", *std_cargo_args(path: ".")
+    system "cargo", "install", *std_cargo_args
   end
 
   test do


### PR DESCRIPTION
Built and validated locally with `brew style` and `brew audit --strict`.

Syntax-only change: replace `*std_cargo_args(path: ".")` with bare `*std_cargo_args`.
