### PR TITLE
claws 0.15.2 (new formula)

### DIFF
--- a/Formula/c/claws.rb
+++ b/Formula/c/claws.rb
@@ -1,0 +1,24 @@
+class Claws < Formula
+  desc "Terminal UI for AWS resource management"
+  homepage "https://github.com/clawscli/claws"
+  url "https://github.com/clawscli/claws/archive/refs/tags/v0.15.2.tar.gz"
+  sha256 "16417cda3d17a3dc790877cb2570185f45aff408dac6ff5215aac42a9ea0635b"
+  license "Apache-2.0"
+  head "https://github.com/clawscli/claws.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.version=#{version}"
+
+    system "go", "build", *std_go_args(ldflags:, output: bin/"claws"), "./cmd/claws"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/claws --version")
+
+    output = shell_output("#{bin}/claws --profile invalid/name 2>&1", 1)
+    assert_match "Error: invalid profile name: invalid/name", output
+    assert_match "Valid characters: alphanumeric, hyphen, underscore, period", output
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

New formula for claws.

AI-assisted: formula drafting and packaging review; manually verified with local brew ops.
