### PR TITLE
fat: use zlib-ng-compat on Linux

### DIFF
--- a/Formula/f/fat.rb
+++ b/Formula/f/fat.rb
@@ -19,7 +19,10 @@ class Fat < Formula
   depends_on "libzip"
 
   uses_from_macos "ncurses"
-  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "make", "install", "PREFIX=#{prefix}"


### PR DESCRIPTION
Style and audit pass locally on macOS.

Replaces `uses_from_macos \"zlib\"` with a Linux-only `depends_on \"zlib-ng-compat\"` block.
