### PR TITLE
gittype: use zlib-ng-compat on Linux

### DIFF
--- a/Formula/g/gittype.rb
+++ b/Formula/g/gittype.rb
@@ -19,7 +19,9 @@ class Gittype < Formula
   depends_on "rust" => :build
   depends_on "openssl@3"
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
Style and audit pass locally on macOS.

Replaces `uses_from_macos \"zlib\"` with a Linux-only `depends_on \"zlib-ng-compat\"` block.
