### PR TITLE
gritql: use zlib-ng-compat on Linux

### DIFF
--- a/Formula/g/gritql.rb
+++ b/Formula/g/gritql.rb
@@ -19,7 +19,9 @@ class Gritql < Formula
   depends_on "rust" => :build
   depends_on "openssl@3"
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args(path: "crates/cli_bin")


### PR DESCRIPTION
Style and audit pass locally on macOS.

Replaces `uses_from_macos \"zlib\"` with a Linux-only `depends_on \"zlib-ng-compat\"` block.
