### PR TITLE
huber: use zlib-ng-compat on Linux

### DIFF
--- a/Formula/h/huber.rb
+++ b/Formula/h/huber.rb
@@ -19,7 +19,9 @@ class Huber < Formula
 
   depends_on "openssl@3"
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     # Ensure that the `openssl` crate picks up the intended library.


### PR DESCRIPTION
Style and audit pass locally on macOS.

Replaces `uses_from_macos \"zlib\"` with a Linux-only `depends_on \"zlib-ng-compat\"` block.
