### PR TITLE
jarl: use zlib-ng-compat on Linux

### DIFF
--- a/Formula/j/jarl.rb
+++ b/Formula/j/jarl.rb
@@ -17,7 +17,9 @@ class Jarl < Formula
 
   depends_on "rust" => :build
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args(path: "crates/jarl")


### PR DESCRIPTION
Style and audit pass locally on macOS.

Replaces `uses_from_macos \"zlib\"` with a Linux-only `depends_on \"zlib-ng-compat\"` block.
