### PR TITLE
pls: use zlib-ng-compat on Linux

### DIFF
--- a/Formula/p/pls.rb
+++ b/Formula/p/pls.rb
@@ -20,7 +20,9 @@ class Pls < Formula
 
   depends_on "rust" => :build
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
Style and audit pass locally on macOS.

Replaces `uses_from_macos \"zlib\"` with a Linux-only `depends_on \"zlib-ng-compat\"` block.
