### PR TITLE
tickrs: use zlib-ng-compat on Linux

### DIFF
--- a/Formula/t/tickrs.rb
+++ b/Formula/t/tickrs.rb
@@ -18,10 +18,9 @@ class Tickrs < Formula
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
-  uses_from_macos "zlib"
-
   on_linux do
     depends_on "openssl@3"
+    depends_on "zlib-ng-compat"
   end
 
   def install


### PR DESCRIPTION
Style and audit pass locally on macOS.

Replaces `uses_from_macos \"zlib\"` with a Linux-only `depends_on \"zlib-ng-compat\"` block.
