### PR TITLE
zig@0.13: use zlib-ng-compat on Linux

### DIFF
--- a/Formula/z/zig@0.13.rb
+++ b/Formula/z/zig@0.13.rb
@@ -26,7 +26,10 @@ class ZigAT013 < Formula
   depends_on "zstd"
 
   uses_from_macos "ncurses"
-  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   # https://github.com/Homebrew/homebrew-core/issues/209483
   skip_clean "lib/zig/libc/darwin/libSystem.tbd"


### PR DESCRIPTION
Style and audit pass locally on macOS.

Replaces `uses_from_macos \"zlib\"` with a Linux-only `depends_on \"zlib-ng-compat\"` block.
