### PR TITLE
typeui-sh: avoid HOME override in test

### DIFF
--- a/Formula/t/typeui-sh.rb
+++ b/Formula/t/typeui-sh.rb
@@ -23,8 +23,6 @@ class TypeuiSh < Formula
   end
 
   test do
-    ENV["HOME"] = testpath
-
     (testpath/".typeui-sh").mkpath
     (testpath/".typeui-sh/license.json").write <<~JSON
       {


### PR DESCRIPTION
Style and audit pass locally on macOS.

Removes the explicit `HOME` override from `test do`; `brew test` already provides an isolated home directory.
