### PR TITLE
zombie: avoid HOME override in test

### DIFF
--- a/Formula/z/zombie.rb
+++ b/Formula/z/zombie.rb
@@ -22,8 +22,6 @@ class Zombie < Formula
   end
 
   test do
-    ENV["HOME"] = testpath
-
     history_path = if OS.mac?
       testpath/"Library/Application Support/com.zombie.cli/history.json"
     else


### PR DESCRIPTION
Style and audit pass locally on macOS.

Removes the explicit `HOME` override from `test do`; `brew test` already provides an isolated home directory.
