### PR TITLE
skills: add actions restart helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,17 @@ When using `gh` to create/edit PRs or issues:
 - For Linux failures, use the [Homebrew Docker container](CONTRIBUTING.md#homebrew-docker-container)
 - If stuck, comment describing what you've tried
 
+### Restarting GitHub Actions Runs
+
+- For tap PR check refreshes, use the repo-local skill at `skills/restart-github-actions-runs/SKILL.md`.
+- Prefer the helper:
+  ```sh
+  skills/restart-github-actions-runs/scripts/restart_pr_actions.sh --repo chenrui333/homebrew-tap <pr> [<pr> ...]
+  ```
+- The helper prefers a safe empty-amend + `git push --force-with-lease` on verified same-repo PR head branches, and falls back to `gh run rerun` when the head branch is missing or otherwise not safe to push.
+- Never edit workflow files just to restart checks.
+- Never force-push `main`.
+
 ## AI Disclosure
 
 If AI assisted with the PR, check the AI checkbox in the PR template and briefly describe:

--- a/skills/restart-github-actions-runs/SKILL.md
+++ b/skills/restart-github-actions-runs/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: restart-github-actions-runs
+description: Restart GitHub Actions for one or more tap PRs by safely force-updating same-repo PR head branches or rerunning the latest PR workflow runs when the head branch is missing or not pushable. Use when asked to rerun, restart, or refresh CI checks for `chenrui333/homebrew-tap` without editing workflows, and never force-push `main`.
+---
+
+# Restart GitHub Actions Runs
+
+Use this skill when the goal is to refresh GitHub Actions runs for open PRs in this tap without changing workflow files.
+
+## Guardrails
+
+- Never edit workflows just to restart checks.
+- Never force-push `main`.
+- Only force-update verified PR head branches that are open, same-repo, and not `main`.
+- If the PR head branch is missing, cross-repo, or otherwise not pushable, rerun the existing workflow runs with `gh run rerun` instead.
+
+## Preferred Command
+
+Run the helper from the repo root:
+
+```sh
+skills/restart-github-actions-runs/scripts/restart_pr_actions.sh \
+  --repo chenrui333/homebrew-tap \
+  <pr> [<pr> ...]
+```
+
+Examples:
+
+```sh
+skills/restart-github-actions-runs/scripts/restart_pr_actions.sh --repo chenrui333/homebrew-tap 4991 4990 4989
+skills/restart-github-actions-runs/scripts/restart_pr_actions.sh --dry-run --repo chenrui333/homebrew-tap 4991
+```
+
+## What The Script Does
+
+1. Read PR metadata with `gh pr view`.
+2. If the PR is open, same-repo, and its head branch still exists on `origin` and is not `main`, create an empty amend on that branch tip in a scratch clone and push it back with `--force-with-lease`.
+3. Otherwise, collect the latest workflow run IDs from `gh pr checks` and rerun those runs directly with `gh run rerun`.
+4. Print a per-PR action summary so follow-up checks are easy.
+
+## Verification
+
+After restarting runs, check status with:
+
+```sh
+gh pr checks <pr> --repo chenrui333/homebrew-tap
+gh pr view <pr> --repo chenrui333/homebrew-tap --json url,headRefName,headRefOid
+```
+
+A fresh restart should show new `pending` checks or newly queued workflow runs.

--- a/skills/restart-github-actions-runs/scripts/restart_pr_actions.sh
+++ b/skills/restart-github-actions-runs/scripts/restart_pr_actions.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  restart_pr_actions.sh [--repo owner/repo] [--dry-run] <pr> [<pr> ...]
+
+Behavior:
+  - Prefer a safe empty-amend + force-with-lease on same-repo PR head branches.
+  - Fall back to `gh run rerun` when the PR head branch is missing, cross-repo,
+    or not safe to push.
+
+Options:
+  --repo <owner/repo>  GitHub repo. Defaults to the current git origin if possible.
+  --dry-run            Print planned actions without mutating GitHub.
+  -h, --help           Show help.
+
+Safety:
+  - Never force-pushes `main`.
+  - Only force-updates open, same-repo PR head branches that still exist on origin.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+normalize_pr() {
+  local input="$1"
+  if [[ "$input" =~ ^https?://github\.com/.*/pull/([0-9]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo "$input"
+  fi
+}
+
+extract_repo_from_origin() {
+  local remote
+  remote=$(git remote get-url origin 2>/dev/null || true)
+  if [[ -z "$remote" ]]; then
+    return 1
+  fi
+  if [[ "$remote" =~ github\.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+collect_run_ids() {
+  local pr="$1"
+  local repo="$2"
+  gh pr checks "$pr" --repo "$repo" --json link |
+    jq -r '.[].link | select(test("/actions/runs/[0-9]+")) | capture("/actions/runs/(?<id>[0-9]+)").id' |
+    sort -u
+}
+
+rerun_runs() {
+  local pr="$1"
+  local repo="$2"
+  local dry_run="$3"
+  local ids
+
+  ids=$(collect_run_ids "$pr" "$repo" || true)
+  if [[ -z "$ids" ]]; then
+    echo "FALLBACK pr=$pr mode=rerun status=no-runs-found"
+    return 0
+  fi
+
+  while IFS= read -r run_id; do
+    [[ -n "$run_id" ]] || continue
+    if (( dry_run )); then
+      echo "PLAN pr=$pr mode=rerun run=$run_id"
+    else
+      gh run rerun "$run_id" --repo "$repo" >/dev/null
+      echo "RERUN pr=$pr run=$run_id"
+    fi
+  done <<<"$ids"
+}
+
+REPO=""
+DRY_RUN=0
+PRS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || die "--repo requires a value"
+      REPO="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -* )
+      die "unknown option: $1"
+      ;;
+    *)
+      PRS+=("$(normalize_pr "$1")")
+      shift
+      ;;
+  esac
+done
+
+[[ ${#PRS[@]} -gt 0 ]] || { usage; exit 1; }
+require_cmd gh
+require_cmd git
+require_cmd jq
+
+gh auth status -h github.com >/dev/null 2>&1 || die "gh is not authenticated"
+
+if [[ -z "$REPO" ]]; then
+  REPO=$(extract_repo_from_origin) || die "--repo is required outside a git checkout with a GitHub origin"
+fi
+
+scratch=$(mktemp -d /private/tmp/restart-pr-actions.XXXXXX)
+trap 'rm -rf "$scratch"' EXIT
+
+git clone --filter=blob:none --no-checkout "git@github.com:${REPO}.git" "$scratch" >/dev/null 2>&1
+cd "$scratch"
+
+name=$(git -C /opt/homebrew/Homebrew/Library/Taps/chenrui333/homebrew-tap config user.name || true)
+email=$(git -C /opt/homebrew/Homebrew/Library/Taps/chenrui333/homebrew-tap config user.email || true)
+[[ -n "$name" ]] && git config user.name "$name"
+[[ -n "$email" ]] && git config user.email "$email"
+
+for pr in "${PRS[@]}"; do
+  meta=$(gh pr view "$pr" --repo "$REPO" --json number,state,headRefName,headRefOid,isCrossRepository,title,url)
+  state=$(jq -r '.state' <<<"$meta")
+  branch=$(jq -r '.headRefName' <<<"$meta")
+  sha=$(jq -r '.headRefOid' <<<"$meta")
+  cross=$(jq -r '.isCrossRepository' <<<"$meta")
+  title=$(jq -r '.title' <<<"$meta")
+
+  if [[ "$state" != "OPEN" ]]; then
+    echo "SKIP pr=$pr state=$state title=$(printf %q "$title")"
+    continue
+  fi
+
+  if [[ "$branch" == "main" ]]; then
+    echo "FALLBACK pr=$pr mode=rerun reason=head-is-main"
+    rerun_runs "$pr" "$REPO" "$DRY_RUN"
+    continue
+  fi
+
+  if [[ "$cross" == "false" ]] && git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    if (( DRY_RUN )); then
+      echo "PLAN pr=$pr mode=force-update branch=$branch sha=${sha:0:12}"
+      continue
+    fi
+
+    git fetch --no-tags origin "$branch" >/dev/null 2>&1
+    git checkout --detach FETCH_HEAD >/dev/null 2>&1
+    old=$(git rev-parse --short=12 HEAD)
+    git commit --amend --no-edit --allow-empty >/dev/null 2>&1
+    new=$(git rev-parse --short=12 HEAD)
+    git push --force-with-lease origin HEAD:"$branch" >/dev/null 2>&1
+    echo "REFRESHED pr=$pr mode=force-update branch=$branch old=$old new=$new"
+    continue
+  fi
+
+  echo "FALLBACK pr=$pr mode=rerun reason=head-not-pushable branch=$branch sha=${sha:0:12}"
+  rerun_runs "$pr" "$REPO" "$DRY_RUN"
+done


### PR DESCRIPTION
Adds a repo-local skill and helper script for restarting GitHub Actions runs on tap PRs.

- prefers a safe empty-amend + force-with-lease on verified PR head branches
- falls back to `gh run rerun` when a PR head branch is missing or not pushable
- documents the workflow in `AGENTS.md`

Validation:
- `bash -n skills/restart-github-actions-runs/scripts/restart_pr_actions.sh`
- `skills/restart-github-actions-runs/scripts/restart_pr_actions.sh --help`
- `skills/restart-github-actions-runs/scripts/restart_pr_actions.sh --dry-run --repo chenrui333/homebrew-tap 4991 4990`
