### PR TITLE
tooling: add mise toolchain

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+
+ignore: |
+  .lycheecache
+
+rules:
+  document-start: disable
+  line-length: disable
+  truthy:
+    check-keys: false

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+[tools]
+actionlint = "1.7.11"
+yamllint = "1.38.0"
+shellcheck = "0.11.0"
+shfmt = "3.12.0"
+typos = "1.44.0"
+zizmor = "1.23.1"
+python = "3.13"


### PR DESCRIPTION
Adds a repo-local `mise.toml` so the GitHub workflow and repo hygiene tools are installable with one command.

Included tools:
- `actionlint`
- `yamllint`
- `shellcheck`
- `shfmt`
- `typos`
- `zizmor`
- `python`

Also adds an initial `.yamllint` profile tuned for the current repo layout.

Validation:
- `mise install`
- `mise exec -- actionlint -version`
- `mise exec -- yamllint --version`
- `mise exec -- shellcheck --version`
- `mise exec -- shfmt --version`
- `mise exec -- typos --version`
- `mise exec -- zizmor --version`

Follow-up cleanup of existing lint findings is intentionally left for a separate PR.
