### PR TITLE
triage: label skills changes

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -49,6 +49,10 @@ jobs:
               path: \.github/autobump\.txt
               allow_any_match: true
 
+            - label: skills
+              path: skills/.+
+              allow_any_match: true
+
             - label: missing license
               path: Formula/.+
               missing_content: \n  license .+\n


### PR DESCRIPTION
Adds a `skills` triage label rule for pull requests that modify files under `skills/`.

Validation:
- `mise exec -- actionlint .github/workflows/triage.yml`
- `mise exec -- yamllint .github/workflows/triage.yml`
