### PR TITLE
scripts: format update-list with shfmt

### DIFF
--- a/.github/scripts/update-list.sh
+++ b/.github/scripts/update-list.sh
@@ -2,20 +2,20 @@
 
 # 1. Get only the short formula names (strip chenrui333/tap/).
 FORMULAE="$(
-  brew tap-info chenrui333/tap --json \
-    | jq -r '.[0].formula_names[]' \
-    | sed 's|^chenrui333/tap/||'
+	brew tap-info chenrui333/tap --json |
+		jq -r '.[0].formula_names[]' |
+		sed 's|^chenrui333/tap/||'
 )"
 
 # 2. Build the lines we want to insert, including bullet points
 FORMATTED_FORMULAE="$(
-  echo "$FORMULAE" | awk '
+	echo "$FORMULAE" | awk '
     $0 == "debugg-ai-mcp" { printf("- `%s` <!-- spellchecker:disable-line -->\n", $0); next }
     { printf("- `%s`\n", $0) }
   '
 )"
 
-cat <<EOF > .tmp-formulae-list
+cat <<EOF >.tmp-formulae-list
 <!-- FORMULAE-LIST-START -->
 <details>
 <summary>Formula List</summary>
@@ -35,8 +35,8 @@ sed -i.bak '/<!-- FORMULAE-LIST-START -->/,/<!-- FORMULAE-LIST-END -->/ {
 rm -f README.md.bak .tmp-formulae-list
 
 if ! git diff --exit-code README.md; then
-  git config user.name "github-actions"
-  git config user.email "actions@github.com"
-  git add README.md
-  git commit -m "Update formulae list"
+	git config user.name "github-actions"
+	git config user.email "actions@github.com"
+	git add README.md
+	git commit -m "Update formulae list"
 fi


### PR DESCRIPTION
Formats `.github/scripts/update-list.sh` with `shfmt` to match the repo toolchain baseline.

Validation:
- `mise exec -- shfmt -d .github/scripts/update-list.sh`
