### PR TITLE
sem-cli 0.3.7 (new formula)

### DIFF
--- a/Formula/s/sem-cli.rb
+++ b/Formula/s/sem-cli.rb
@@ -1,0 +1,45 @@
+class SemCli < Formula
+  desc "Semantic version control CLI with entity-level diffs"
+  homepage "https://github.com/Ataraxy-Labs/sem"
+  url "https://github.com/Ataraxy-Labs/sem/archive/refs/tags/v0.3.7.tar.gz"
+  sha256 "c52f96433958c403ed53886b596a8df76387d37919bee3b9d925dc4f11d4b88d"
+  license any_of: ["MIT", "Apache-2.0"]
+  head "https://github.com/Ataraxy-Labs/sem.git", branch: "main"
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+
+  depends_on "libssh2"
+  depends_on "openssl@3"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
+  conflicts_with "parallel", because: "both install a sem executable"
+
+  def install
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    ENV["OPENSSL_NO_VENDOR"] = "1"
+
+    system "cargo", "install", *std_cargo_args(path: "crates/sem-cli")
+  end
+
+  test do
+    system "git", "init"
+    system "git", "config", "user.email", "test@example.com"
+    system "git", "config", "user.name", "Test User"
+    (testpath/"hello.py").write <<~PYTHON
+      def greet():
+          print("hello")
+    PYTHON
+    system "git", "add", "hello.py"
+    system "git", "commit", "-m", "init"
+
+    output = shell_output("#{bin}/sem diff --commit HEAD --format json")
+    json = JSON.parse(output)
+    assert_equal 1, json["changes"].length
+    assert_equal "function", json["changes"][0]["entityType"]
+    assert_equal "greet", json["changes"][0]["entityName"]
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.1 and Linux.

New formula for the semantic version control CLI with entity-level diffs.
