### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.yml,*.yaml,*.json,*.json5,*.js,*.mjs,*.cjs,*.rb,*.toml}]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[justfile]
+indent_style = space
+indent_size = 4
+
+[{*.sh,*.bash}]
+indent_style = tab
+tab_width = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Adds a repo-local `.editorconfig` for the current file conventions.

Included defaults:
- UTF-8, LF, final newline
- trailing whitespace trimmed by default
- markdown keeps trailing whitespace
- 2-space indentation for YAML/JSON/JS/Ruby/TOML
- 4-space indentation for Python and `justfile`
- tabs for shell scripts and `Makefile`

This PR only adds the config file. It does not reformat existing files.
