### PR TITLE
tooling: add just to mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 actionlint = "1.7.11"
+just = "1.46.0"
 yamllint = "1.38.0"
 shellcheck = "0.11.0"
 shfmt = "3.12.0"


### PR DESCRIPTION
Adds `just` to the repo `mise.toml` toolchain.

Validation:
- `mise install just`
- `mise exec -- just --version`
