### PR TITLE
lightpanda-v8 0.3.3 (new formula)

### DIFF
--- a/Formula/l/lightpanda-v8.rb
+++ b/Formula/l/lightpanda-v8.rb
@@ -1,0 +1,62 @@
+class LightpandaV8 < Formula
+  desc "Fork-specific V8 archive and Zig module layout for Lightpanda"
+  homepage "https://github.com/lightpanda-io/zig-v8-fork"
+  url "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.3.3.tar.gz"
+  sha256 "aab25cc9c479215afe21d2cb0007b6cdfcd6d8cb501441553f60b96bb2dba02b"
+  license "MIT"
+  head "https://github.com/lightpanda-io/zig-v8-fork.git", branch: "main"
+
+  if OS.mac? && Hardware::CPU.arm?
+    resource "libc_v8" do
+      url "https://github.com/lightpanda-io/zig-v8-fork/releases/download/v0.3.3/libc_v8_14.0.365.4_macos_aarch64.a"
+      sha256 "c9fb1286e07447d097a704d5ff1b305172f359796e20aaf132deee2d502acca0"
+    end
+  elsif OS.mac? && Hardware::CPU.intel?
+    resource "libc_v8" do
+      url "https://github.com/lightpanda-io/zig-v8-fork/releases/download/v0.3.3/libc_v8_14.0.365.4_macos_x86_64.a"
+      sha256 "ea2037790c93bb45e8156219fb44638bb9f10ed6cbd988b62d88d39204b40167"
+    end
+  elsif OS.linux? && Hardware::CPU.arm?
+    resource "libc_v8" do
+      url "https://github.com/lightpanda-io/zig-v8-fork/releases/download/v0.3.3/libc_v8_14.0.365.4_linux_aarch64.a"
+      sha256 "1427c46de6da4918597640a720e2ba725410f41dcac57626291dd025a5968f69"
+    end
+  else
+    resource "libc_v8" do
+      url "https://github.com/lightpanda-io/zig-v8-fork/releases/download/v0.3.3/libc_v8_14.0.365.4_linux_x86_64.a"
+      sha256 "b875439b3df025a2da510388559fe66c4454ed660bc38101c54dd55af0b5d0c7"
+    end
+  end
+
+  def install
+    module_root = pkgshare/"zig-v8-fork"
+    module_root.mkpath
+    cp_r Dir["*"] + Dir[".*"] - %w[. ..], module_root
+
+    build_zon = module_root/"build.zig.zon"
+    build_zon_content = build_zon.read
+    unless build_zon_content.sub!(
+      /    \.dependencies = \.\{\n.*?    \},\n(?=    \.paths = \.\{)/m,
+      "    .dependencies = .{},\n",
+    )
+      odie "Failed to rewrite zig-v8-fork dependency stanza"
+    end
+    build_zon_content.gsub!("\"README\",", "\"README.md\",")
+    build_zon.atomic_write build_zon_content
+
+    lib.install resource("libc_v8").cached_download => "libc_v8.a"
+  end
+
+  test do
+    module_root = pkgshare/"zig-v8-fork"
+    assert_path_exists module_root/"build.zig"
+    assert_path_exists module_root/"build.zig.zon"
+    assert_path_exists module_root/"src/v8.zig"
+    assert_path_exists lib/"libc_v8.a"
+
+    build_zon = (module_root/"build.zig.zon").read
+    assert_match ".dependencies = .{},", build_zon
+    assert_match "\"README.md\",", build_zon
+    assert_match "current ar archive", shell_output("file #{lib}/libc_v8.a")
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Packages the fork-specific Zig V8 module layout and matching `libc_v8.a` archive required by Lightpanda.
