### PR TITLE
cmd: tighten python migration helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,21 @@ When using `gh` to create/edit PRs or issues:
 - Avoid passing escaped `\n` in quoted `--body` strings.
 - If inline body text is required, use single quotes around the full body to avoid shell interpolation.
 
+## Tap Maintenance Helpers
+
+For recurring maintenance work in this tap, prefer the repo-local helpers under `cmd/` when they fit:
+
+- `brew migrate-python <formula>`
+  - For tap-local Python migration PRs.
+  - Works against `chenrui333/tap`, refreshes resources with `brew update-python-resources2`, pushes the branch, and opens the PR.
+- `brew check <formula>`
+  - Shortcut for `brew audit --strict --git --online --fix`.
+  - Bare formula names are resolved to `chenrui333/tap/<formula>`.
+- `brew patch <url>`
+  - Fetches a patch URL, computes the SHA-256, and prints a `patch do` block for formula edits.
+
+If a helper does not match the job cleanly, fall back to the explicit `brew`/`gh` commands in this document instead of forcing the helper into a workflow it was not built for.
+
 ## CI Failures
 
 - Reproduce failures locally before debugging

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -6,12 +6,13 @@ This directory contains custom Homebrew commands provided by the `chenrui333/tap
 
 Create a tap PR that migrates a formula from the previous Homebrew `python@X.Y`
 dependency to the current one and refreshes resource blocks with
-`brew update-python-resources`.
+`brew update-python-resources2`.
 
 ### Usage
 
 ```bash
 brew migrate-python readmeai
+brew migrate-python chenrui333/tap/readmeai
 brew migrate-python readmeai --exclude foo,bar
 ```
 
@@ -19,6 +20,7 @@ brew migrate-python readmeai --exclude foo,bar
 
 - Works against `chenrui333/homebrew-tap`
 - Creates a branch from `origin/main`
+- Uses `brew update-python-resources2` so missing sdists are handled in the same tap workflow
 - Pushes the branch and opens a PR automatically
 - Adds the matching `python-X.Y-migration` label when present
 - Requires a clean tracked worktree in the tap
@@ -164,4 +166,5 @@ Run a strict online audit with autofix enabled.
 
 ```bash
 brew check chenrui333/tap/bun
+brew check bun
 ```

--- a/cmd/brew-check
+++ b/cmd/brew-check
@@ -9,8 +9,21 @@ Usage: brew check <formula> [...]
 Run a strict online audit with autofix enabled.
 
 Example:
+  brew check bun
   brew check chenrui333/tap/bun
 EOF
+}
+
+normalize_formula_arg() {
+  local tap="chenrui333/tap"
+  local arg="$1"
+
+  if [[ "$arg" == *.rb || "$arg" == */* ]]; then
+    printf '%s\n' "$arg"
+    return 0
+  fi
+
+  printf '%s\n' "${tap}/${arg}"
 }
 
 if [[ $# -eq 0 ]]; then
@@ -25,4 +38,9 @@ case "${1:-}" in
     ;;
 esac
 
-brew audit --strict --git --online --fix "$@"
+args=()
+for arg in "$@"; do
+  args+=("$(normalize_formula_arg "$arg")")
+done
+
+HOMEBREW_NO_AUTO_UPDATE=1 brew audit --strict --git --online --fix "${args[@]}"

--- a/cmd/brew-migrate-python
+++ b/cmd/brew-migrate-python
@@ -8,12 +8,12 @@ Usage: brew migrate-python <formula> [update-python-resources options]
 
 Create a tap PR that migrates a formula from the previous Homebrew `python@X.Y`
 dependency to the current one returned by `brew which-formula python3`, then
-refresh Python resources with `brew update-python-resources`.
+refresh Python resources with `brew update-python-resources2`.
 
 The command:
   1. creates a branch from `origin/main`
   2. replaces `python@<current-1>` with `python@<current>`
-  3. runs `brew update-python-resources`
+  3. runs `brew update-python-resources2`
   4. commits, pushes, and opens a PR in `chenrui333/homebrew-tap`
 
 Requirements:
@@ -22,6 +22,7 @@ Requirements:
 
 Examples:
   brew migrate-python readmeai
+  brew migrate-python chenrui333/tap/readmeai
   brew migrate-python readmeai --exclude foo,bar
 EOF
 }
@@ -51,6 +52,22 @@ find_formula_path() {
   return 1
 }
 
+normalize_formula_name() {
+  local tap="chenrui333/tap"
+  local arg="$1"
+
+  if [[ "$arg" == "${tap}/"* ]]; then
+    printf '%s\n' "${arg#"${tap}"/}"
+    return 0
+  fi
+
+  if [[ "$arg" == */* ]]; then
+    odie "formula must be in ${tap}; got '${arg}'"
+  fi
+
+  printf '%s\n' "$arg"
+}
+
 if [[ $# -eq 0 ]]; then
   usage
   exit 1
@@ -63,14 +80,14 @@ case "${1:-}" in
     ;;
 esac
 
-formula="$1"
+formula="$(normalize_formula_name "$1")"
 shift
 
 tap="chenrui333/tap"
 repo="chenrui333/homebrew-tap"
-tap_root="$(brew --repository "$tap")"
+tap_root="$(HOMEBREW_NO_AUTO_UPDATE=1 brew --repository "$tap")"
 formula_path="$(find_formula_path "$tap_root" "$formula")" || odie "could not find formula '${formula}' in ${tap}"
-formula_rel="${formula_path#${tap_root}/}"
+formula_rel="${formula_path#"${tap_root}"/}"
 
 token="${HOMEBREW_GITHUB_API_TOKEN:-}"
 if [[ -z "$token" ]]; then
@@ -79,7 +96,7 @@ fi
 [[ -n "$token" ]] || odie "GitHub token required. Run 'gh auth login' or export HOMEBREW_GITHUB_API_TOKEN."
 export GITHUB_TOKEN="$token"
 
-next="$(brew which-formula python3 2>/dev/null | awk -F'@' 'NF > 1 { print $2; exit }')"
+next="$(HOMEBREW_NO_AUTO_UPDATE=1 brew which-formula python3 2>/dev/null | awk -F'@' 'NF > 1 { print $2; exit }')"
 [[ -n "$next" ]] || odie "could not resolve the active Homebrew python3 formula"
 
 curr="$(awk -F. '{ printf "%s.%d", $1, $2 - 1 }' <<<"$next")"
@@ -99,6 +116,10 @@ fi
 
 if git -C "$tap_root" show-ref --verify --quiet "refs/heads/${branch}"; then
   odie "local branch '${branch}' already exists"
+fi
+
+if git -C "$tap_root" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+  odie "remote branch '${branch}' already exists on origin"
 fi
 
 branch_created=false
@@ -133,7 +154,7 @@ export HOMEBREW_PYTHON_MIGRATE_CURR="python@${curr}"
 export HOMEBREW_PYTHON_MIGRATE_NEXT="python@${next}"
 perl -0pi -e 's/\Q$ENV{HOMEBREW_PYTHON_MIGRATE_CURR}\E/$ENV{HOMEBREW_PYTHON_MIGRATE_NEXT}/g' "$formula_path"
 
-brew update-python-resources "${tap}/${formula}" "$@" || true
+HOMEBREW_NO_AUTO_UPDATE=1 brew update-python-resources2 "$formula" "$@"
 
 git -C "$tap_root" add -- "$formula_rel"
 if git -C "$tap_root" diff --cached --quiet -- "$formula_rel"; then


### PR DESCRIPTION
Tighten the newly added tap-maintenance helpers.

Changes:
- make `brew migrate-python` use `brew update-python-resources2` instead of swallowing resource update failures
- accept both bare formula names and `chenrui333/tap/<formula>` in `brew migrate-python`
- refuse reuse of an existing remote branch name in `brew migrate-python`
- default bare `brew check <formula>` arguments to `chenrui333/tap/<formula>`
- set `HOMEBREW_NO_AUTO_UPDATE=1` for the tap-facing `brew` calls in these helpers
- refresh the command docs to match the safer behavior

Validation:
- `bash -n cmd/brew-check cmd/brew-patch cmd/brew-migrate-python`
- `shellcheck cmd/brew-check cmd/brew-patch cmd/brew-migrate-python`
- `brew check`
- `brew patch`
- `brew migrate-python`
