### PR TITLE
ghgrab 1.1.0 (new formula)

### DIFF
--- a/Formula/g/ghgrab.rb
+++ b/Formula/g/ghgrab.rb
@@ -1,0 +1,29 @@
+class Ghgrab < Formula
+  desc "TUI for searching and downloading files from GitHub repositories"
+  homepage "https://github.com/abhixdd/ghgrab"
+  url "https://github.com/abhixdd/ghgrab/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "0b68ec1e7c0a0975f5ddb5e040be4349a4f5657b761c3e7c1a6d302f364cb8c8"
+  license "MIT"
+  head "https://github.com/abhixdd/ghgrab.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    require "json"
+
+    ENV["XDG_CONFIG_HOME"] = testpath/"config"
+    (testpath/"downloads").mkpath
+
+    assert_match version.to_s, shell_output("#{bin}/ghgrab --version")
+    assert_match "saved successfully", shell_output("#{bin}/ghgrab config set path #{testpath/"downloads"}")
+    assert_match "Download Path: #{testpath/"downloads"}", shell_output("#{bin}/ghgrab config list")
+
+    payload = JSON.parse(shell_output("#{bin}/ghgrab agent tree not-a-url"))
+    assert_equal false, payload["ok"]
+    assert_equal "invalid_url", payload.dig("error", "code")
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

Validated on remote Linux and macOS runners before opening.
