### PR TITLE
steamfetch 0.5.2 (new formula)

### DIFF
--- a/Formula/s/steamfetch.rb
+++ b/Formula/s/steamfetch.rb
@@ -1,0 +1,46 @@
+class Steamfetch < Formula
+  desc "Display Steam stats in the terminal"
+  homepage "https://github.com/unhappychoice/steamfetch"
+  url "https://github.com/unhappychoice/steamfetch/archive/refs/tags/v0.5.2.tar.gz"
+  sha256 "9f1b6a201ad3aa2aaa51270f068a109f05ad1d1d2e37c1cae3df88e5f4edf421"
+  license "ISC"
+  head "https://github.com/unhappychoice/steamfetch.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  on_linux do
+    depends_on "pkgconf" => :build
+    depends_on arch: :x86_64 # steamworks 0.12.2 fails to build on Linux arm64
+    depends_on "openssl@3"
+  end
+
+  def install
+    system "cargo", "install", *std_cargo_args
+
+    steam_api = Dir["target/release/build/steamworks-sys-*/out/libsteam_api.*"].first
+    raise "libsteam_api artifact not found" if steam_api.nil?
+
+    (lib/"steamfetch").install steam_api
+
+    if OS.mac?
+      MachO::Tools.change_dylib_id(
+        "#{lib}/steamfetch/libsteam_api.dylib",
+        "@rpath/libsteam_api.dylib",
+      )
+      MachO::Tools.change_install_name(
+        bin/"steamfetch",
+        "@loader_path/libsteam_api.dylib",
+        "@rpath/libsteam_api.dylib",
+      )
+      system "/usr/bin/codesign", "-f", "-s", "-", bin/"steamfetch"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin/"steamfetch"} --version")
+
+    ENV["NO_COLOR"] = "1"
+    output = shell_output("#{bin/"steamfetch"} --demo")
+    assert_match "unhappychoice", output
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS.

New Rust formula for `steamfetch` with source build, Steam API library installation, and macOS relinking/signing for the bundled dylib.

AI assisted with drafting the formula and patching the install layout.
Manual verification: `brew style`, `brew audit --new --strict`, `brew install --build-from-source`, `brew test`, and `brew linkage --test` on local macOS, plus remote macOS validation on the provided runner. A provided Linux upterm session reproduced the missing OpenSSL headers before the patch; final Linux confirmation will come from CI because that session credential expired after disconnect.
