### PR TITLE
rip 0.7.0 (new formula)

### DIFF
--- a/Formula/r/rip.rb
+++ b/Formula/r/rip.rb
@@ -1,0 +1,32 @@
+class Rip < Formula
+  desc "Fuzzy find and kill processes from the terminal"
+  homepage "https://github.com/cesarferreira/rip"
+  url "https://github.com/cesarferreira/rip/archive/refs/tags/v0.7.0.tar.gz"
+  sha256 "c0e57126bb07a11352bccf30e067b35cb9a3928d458789f77157ca2ae038603b"
+  license "MIT"
+  head "https://github.com/cesarferreira/rip.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/rip --version")
+
+    port = free_port
+    ruby = RbConfig.ruby
+    pid = spawn(
+      ruby, "-e",
+      "require 'socket'; server = TCPServer.new('127.0.0.1', #{port}); sleep 60"
+    )
+    sleep 2
+
+    output = shell_output("#{bin}/rip --port #{port} --confirm-nuke")
+    assert_match "Killed", output
+
+    Process.wait(pid)
+    assert_predicate $CHILD_STATUS, :signaled?
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS.

New Rust formula for `rip` with a non-interactive `test do` that kills a throwaway listener by port using `--confirm-nuke`.

AI assisted with drafting the formula and selecting a deterministic test path.
Manual verification: `brew style`, `brew audit --new --strict`, `brew install --build-from-source`, `brew test`, and `brew linkage --test` on local macOS, plus remote macOS validation in progress on the provided runner. Linux validation will come from CI because the provided Linux upterm credential expired after the earlier `steamfetch` rerun.
