### PR TITLE
tascli 0.14.0 (new formula)

### DIFF
--- a/Formula/t/tascli.rb
+++ b/Formula/t/tascli.rb
@@ -6,15 +6,6 @@ class Tascli < Formula
   license "MIT"
   head "https://github.com/Aperocky/tascli.git", branch: "master"
 
-  bottle do
-    root_url "https://ghcr.io/v2/chenrui333/tap"
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "48ef271bb0c2818bc18106e65de71805bcb6e75d3795404cb23eef62182920ac"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6091e0dbc11781f43a183df5edc133611159ee96203697a97eb1758ef1fc871d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "08ca2e093e6ab1e7bcd94299743cb338830ffd998593642edc3ca4843db4927b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "761fceed99115d7b0717c050a22f67300737bef35abd32598773a95c13484888"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "05dac6c5058c39671608707a05be13ad702dd2a7b86520caa3bb715119b750da"
-  end
-
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
Built and tested locally on macOS.

New formula for a local task and record tracking CLI.

AI assisted with formula drafting and command execution. Manual verification: `brew reinstall --build-from-source`, `brew test`, `brew linkage --test`, `brew audit --new --strict --online` on macOS plus `brew audit --new --strict --online --os=linux --arch=all`, and `brew style`.
