### PR TITLE
packemon 1.8.21 (new formula)

### DIFF
--- a/Formula/p/packemon.rb
+++ b/Formula/p/packemon.rb
@@ -1,0 +1,25 @@
+class Packemon < Formula
+  desc "Terminal tool for generating and monitoring packets"
+  homepage "https://github.com/ddddddO/packemon"
+  url "https://github.com/ddddddO/packemon/archive/refs/tags/v1.8.21.tar.gz"
+  sha256 "843acc971cf5191fd7d06266a582444f478372a2232e77497dc3e73be23b2b77"
+  license "BSD-2-Clause"
+  head "https://github.com/ddddddO/packemon.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.Version=#{version} -X main.Revision=brew"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/packemon"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/packemon version")
+
+    interfaces = JSON.parse(shell_output("#{bin}/packemon interfaces --json"))
+    assert_kind_of Array, interfaces
+    refute_empty interfaces
+    assert_kind_of Hash, interfaces.first
+    assert interfaces.first.key?("InterfaceName")
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS.

New formula for the upstream Go packet monitor and generator TUI.
