### PR TITLE
ytsurf 3.1.5 (new formula)

### DIFF
--- a/Formula/y/ytsurf.rb
+++ b/Formula/y/ytsurf.rb
@@ -1,0 +1,66 @@
+class Ytsurf < Formula
+  desc "YouTube in your terminal without the usual browser clutter"
+  homepage "https://github.com/Stan-breaks/ytsurf"
+  url "https://github.com/Stan-breaks/ytsurf/archive/refs/tags/v3.1.5.tar.gz"
+  sha256 "03ef4d50c1821df5f7e476efc4a6da684af5590a7493714722e71d75b8c229e8"
+  license "GPL-3.0-only"
+  head "https://github.com/Stan-breaks/ytsurf.git", branch: "main"
+
+  depends_on "bash"
+  depends_on "chafa"
+  depends_on "ffmpeg"
+  depends_on "fzf"
+  depends_on "jq"
+  depends_on "mpv"
+  depends_on "yt-dlp"
+
+  def install
+    inreplace "ytsurf.sh", "#!/usr/bin/env bash", "#!#{Formula["bash"].opt_bin}/bash"
+
+    libexec.install "ytsurf.sh" => "ytsurf"
+
+    path = [
+      Formula["chafa"].opt_bin,
+      Formula["ffmpeg"].opt_bin,
+      Formula["fzf"].opt_bin,
+      Formula["jq"].opt_bin,
+      Formula["mpv"].opt_bin,
+      Formula["yt-dlp"].opt_bin,
+      "${PATH}",
+    ].join(":")
+    (bin/"ytsurf").write_env_script(libexec/"ytsurf", PATH: path)
+  end
+
+  test do
+    require "open3"
+
+    testbin = testpath/"test-bin"
+    testbin.mkpath
+
+    (testbin/"nvim").write <<~SH
+      #!/bin/sh
+      printf '%s\n' "$1" > "#{testpath}/editor-path"
+      test -f "$1"
+    SH
+    chmod 0755, testbin/"nvim"
+
+    env = {
+      "HOME"            => testpath.to_s,
+      "PATH"            => "#{testbin}:#{ENV.fetch("PATH")}",
+      "XDG_CACHE_HOME"  => (testpath/"cache").to_s,
+      "XDG_CONFIG_HOME" => (testpath/"config").to_s,
+    }
+
+    version_output, status = Open3.capture2e(env, bin/"ytsurf", "--version")
+    assert_predicate status, :success?
+    assert_match version.to_s, version_output
+
+    output, status = Open3.capture2e(env, bin/"ytsurf", "--edit")
+    assert_predicate status, :success?
+    assert_equal "", output
+
+    config_file = testpath/"config/ytsurf/config"
+    assert_path_exists config_file
+    assert_equal config_file.to_s, (testpath/"editor-path").read.strip
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.3.

Adds a new formula for the upstream terminal YouTube browser.
