### PR TITLE
dart-sass 1.98.0 (new formula)

### DIFF
--- a/Formula/d/dart-sass.rb
+++ b/Formula/d/dart-sass.rb
@@ -39,10 +39,8 @@ class DartSass < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/dart-sass --version")
-
     (testpath/"test.scss").write(".class { property: 1 + 1; }\n")
-    output = shell_output("#{bin}/sass test.scss")
+    output = shell_output("#{bin}/dart-sass test.scss")
     assert_match ".class {", output
     assert_match "property: 2;", output
   end

--- a/Formula/d/dart-sass.rb
+++ b/Formula/d/dart-sass.rb
@@ -27,14 +27,31 @@ class DartSass < Formula
     ENV.delete "UPDATE_SASS_PROTOCOL"
 
     protocol_version = (buildpath/"build/language/spec/EMBEDDED_PROTOCOL_VERSION").read.strip
+    if OS.linux?
+      system dart, "compile", "jit-snapshot",
+             "-Dversion=#{version}",
+             "-Dcompiler-version=#{version}",
+             "-Dprotocol-version=#{protocol_version}",
+             "-o", "sass.snapshot",
+             "bin/sass.dart", "--version"
 
-    system dart, "compile", "exe",
-           "-Dversion=#{version}",
-           "-Dcompiler-version=#{version}",
-           "-Dprotocol-version=#{protocol_version}",
-           "bin/sass.dart", "-o", "sass"
+      libexec.install "sass.snapshot"
+      cp dart, libexec
 
-    bin.install "sass"
+      (bin/"sass").write <<~SH
+        #!/bin/sh
+        exec "#{libexec}/dart" "#{libexec}/sass.snapshot" "$@"
+      SH
+      chmod 0555, bin/"sass"
+    else
+      system dart, "compile", "exe",
+             "-Dversion=#{version}",
+             "-Dcompiler-version=#{version}",
+             "-Dprotocol-version=#{protocol_version}",
+             "bin/sass.dart", "-o", "sass"
+
+      bin.install "sass"
+    end
   end
 
   test do

--- a/Formula/d/dart-sass.rb
+++ b/Formula/d/dart-sass.rb
@@ -7,7 +7,8 @@ class DartSass < Formula
   head "https://github.com/sass/dart-sass.git", branch: "main"
 
   depends_on "buf" => :build
-  depends_on "dart-sdk" => :build
+  depends_on "dart-sdk" if OS.linux?
+  depends_on "dart-sdk" => :build unless OS.linux?
 
   resource "language" do
     url "https://github.com/sass/sass.git",
@@ -15,7 +16,7 @@ class DartSass < Formula
   end
 
   def install
-    dart = Formula["dart-sdk"].opt_bin/"dart"
+    dart = Formula["dart-sdk"].opt_libexec/"bin/dart"
 
     ENV["PUB_ENVIRONMENT"] = "homebrew:dart-sass"
 
@@ -36,11 +37,10 @@ class DartSass < Formula
              "bin/sass.dart", "--version"
 
       libexec.install "sass.snapshot"
-      cp dart, libexec
 
       (bin/"sass").write <<~SH
         #!/bin/sh
-        exec "#{libexec}/dart" "#{libexec}/sass.snapshot" "$@"
+        exec "#{Formula["dart-sdk"].opt_libexec}/bin/dart" "#{libexec}/sass.snapshot" "$@"
       SH
       chmod 0555, bin/"sass"
     else

--- a/Formula/d/dart-sass.rb
+++ b/Formula/d/dart-sass.rb
@@ -1,0 +1,49 @@
+class DartSass < Formula
+  desc "Reference implementation of Sass stylesheet compiler"
+  homepage "https://sass-lang.com"
+  url "https://github.com/sass/dart-sass/archive/refs/tags/1.98.0.tar.gz"
+  sha256 "2eab6aebaba4e095e67b970baf8b0bdb4b934be17fdee1ca5d5da6a490b5517a"
+  license "MIT"
+  head "https://github.com/sass/dart-sass.git", branch: "main"
+
+  depends_on "buf" => :build
+  depends_on "dart-sdk" => :build
+
+  resource "language" do
+    url "https://github.com/sass/sass.git",
+        revision: "cb35c3f36f60be3e1c4bccbae9d6b646e77f4b87"
+  end
+
+  def install
+    dart = Formula["dart-sdk"].opt_bin/"dart"
+
+    ENV["PUB_ENVIRONMENT"] = "homebrew:dart-sass"
+
+    (buildpath/"build/language").install resource("language")
+
+    system dart, "pub", "get"
+    ENV["UPDATE_SASS_PROTOCOL"] = "false"
+    system dart, "run", "grinder", "protobuf"
+    ENV.delete "UPDATE_SASS_PROTOCOL"
+
+    protocol_version = (buildpath/"build/language/spec/EMBEDDED_PROTOCOL_VERSION").read.strip
+
+    system dart, "compile", "exe",
+           "-Dversion=#{version}",
+           "-Dcompiler-version=#{version}",
+           "-Dprotocol-version=#{protocol_version}",
+           "bin/sass.dart", "-o", "sass"
+
+    bin.install "sass"
+    bin.install_symlink "sass" => "dart-sass"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/dart-sass --version")
+
+    (testpath/"test.scss").write(".class { property: 1 + 1; }\n")
+    output = shell_output("#{bin}/sass test.scss")
+    assert_match ".class {", output
+    assert_match "property: 2;", output
+  end
+end

--- a/Formula/d/dart-sass.rb
+++ b/Formula/d/dart-sass.rb
@@ -35,16 +35,11 @@ class DartSass < Formula
            "bin/sass.dart", "-o", "sass"
 
     bin.install "sass"
-    (bin/"dart-sass").write <<~SH
-      #!/bin/sh
-      exec "$(dirname "$0")/sass" "$@"
-    SH
-    chmod 0555, bin/"dart-sass"
   end
 
   test do
     (testpath/"test.scss").write(".class { property: 1 + 1; }\n")
-    output = shell_output("#{bin}/dart-sass test.scss")
+    output = shell_output("#{bin}/sass test.scss")
     assert_match ".class {", output
     assert_match "property: 2;", output
   end

--- a/Formula/d/dart-sass.rb
+++ b/Formula/d/dart-sass.rb
@@ -35,7 +35,11 @@ class DartSass < Formula
            "bin/sass.dart", "-o", "sass"
 
     bin.install "sass"
-    bin.install_symlink "sass" => "dart-sass"
+    (bin/"dart-sass").write <<~SH
+      #!/bin/sh
+      exec "$(dirname "$0")/sass" "$@"
+    SH
+    chmod 0555, bin/"dart-sass"
   end
 
   test do


### PR DESCRIPTION
Built and tested locally on macOS Tahoe.

Adds a source-built `dart-sass` formula for the Dart Sass reference compiler.

Validation:
- `HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install --formula --build-from-source ./Formula/d/dart-sass.rb`
- `HOMEBREW_NO_AUTO_UPDATE=1 brew test dart-sass`
- `HOMEBREW_NO_AUTO_UPDATE=1 brew linkage --test dart-sass`
- `HOMEBREW_NO_AUTO_UPDATE=1 brew audit --new --strict --online chenrui333/tap/dart-sass`
- `HOMEBREW_NO_AUTO_UPDATE=1 brew style Formula/d/dart-sass.rb`
