### PR TITLE
oh-my-claude-sisyphus 4.9.3 (new formula)

### DIFF
--- a/Formula/o/oh-my-claude-sisyphus.rb
+++ b/Formula/o/oh-my-claude-sisyphus.rb
@@ -1,0 +1,28 @@
+class OhMyClaudeSisyphus < Formula
+  desc "Teams-first multi-agent orchestration for Claude Code"
+  homepage "https://github.com/Yeachan-Heo/oh-my-claudecode"
+  url "https://registry.npmjs.org/oh-my-claude-sisyphus/-/oh-my-claude-sisyphus-4.9.3.tgz"
+  sha256 "0d62ea8124c4d6fb371571c53029cfdabdfaa0b5eb81e1a558e4638c629da760"
+  license "MIT"
+  head "https://github.com/Yeachan-Heo/oh-my-claudecode.git", branch: "main"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+
+    # Remove vendored prebuilt ripgrep binaries that cause Mach-O relocation failures
+    vendor_dir = libexec/"lib/node_modules/oh-my-claude-sisyphus/node_modules" \
+                         "/@anthropic-ai/claude-agent-sdk/vendor"
+    rm_r(vendor_dir) if vendor_dir.exist?
+  end
+
+  test do
+    pkg = libexec/"lib/node_modules/oh-my-claude-sisyphus/package.json"
+    assert_match version.to_s, shell_output("node -p \"require('#{pkg}').version\"").strip
+
+    output = shell_output("#{bin}/omc --help 2>&1")
+    assert_match "omc", output
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.2 (arm64).

Removes vendored prebuilt ripgrep binaries from @anthropic-ai/claude-agent-sdk that cause Mach-O relocation failures.