### PR TITLE
get-shit-done-cc 1.34.2 (new formula)

### DIFF
--- a/Formula/g/get-shit-done-cc.rb
+++ b/Formula/g/get-shit-done-cc.rb
@@ -1,0 +1,25 @@
+class GetShitDoneCc < Formula
+  desc "Meta-prompting and context engineering system for AI coding agents"
+  homepage "https://github.com/gsd-build/get-shit-done"
+  url "https://github.com/gsd-build/get-shit-done/archive/refs/tags/v1.34.2.tar.gz"
+  sha256 "00fd3dd3f253a3f9384cff5c0601ac31a7a8da7e5be02b1f76c7015e18cdce72"
+  license "MIT"
+  head "https://github.com/gsd-build/get-shit-done.git", branch: "main"
+
+  depends_on "node"
+
+  def install
+    system "npm", "run", "build:hooks"
+    libexec.install Dir["*"]
+    node_modules = libexec/"node_modules"
+    node_modules.mkpath
+    (bin/"get-shit-done-cc").write_env_script libexec/"bin/install.js",
+                                              PATH: "#{Formula["node"].opt_bin}:$PATH"
+  end
+
+  test do
+    output = shell_output("#{bin}/get-shit-done-cc --help")
+    assert_match "Get Shit Done", output
+    assert_match version.to_s, output
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 15.4 (Apple Silicon).

New formula for [get-shit-done-cc](https://github.com/gsd-build/get-shit-done), a meta-prompting and context engineering system for AI coding agents.
