### PR TITLE
hyprmoncfg 1.2.0 (new formula)

### DIFF
--- a/Formula/h/hyprmoncfg.rb
+++ b/Formula/h/hyprmoncfg.rb
@@ -1,0 +1,24 @@
+class Hyprmoncfg < Formula
+  desc "Terminal-first monitor configurator and daemon for Hyprland"
+  homepage "https://hyprmoncfg.dev/"
+  url "https://github.com/crmne/hyprmoncfg/archive/refs/tags/v1.2.0.tar.gz"
+  sha256 "8111c2081f1d99105058437eae29e2fb0c6301d16597c00c1cefbef78b7ba86f"
+  license "MIT"
+  head "https://github.com/crmne/hyprmoncfg.git", branch: "main"
+
+  depends_on "go" => :build
+  depends_on :linux
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/crmne/hyprmoncfg/internal/buildinfo.Version=#{version}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/hyprmoncfg"
+    system "go", "build", *std_go_args(ldflags:, output: bin/"hyprmoncfgd"), "./cmd/hyprmoncfgd"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/hyprmoncfg version")
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 15.4 (Apple Silicon). Linux-only formula (Hyprland monitor configurator).

New formula for [hyprmoncfg](https://github.com/crmne/hyprmoncfg), a terminal-first monitor configurator and daemon for Hyprland.
