### PR TITLE
renovate: add explicit commitMessagePrefix

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     ':configMigration',
     ':pinDevDependencies',
   ],
+  commitMessagePrefix: 'chore(deps):',
   commitMessageSuffix: ' in {{packageFile}}',
   automerge: true,
   automergeType: 'pr',


### PR DESCRIPTION
The `config:recommended` preset recently stopped including `chore(deps):` as
the default commit message prefix.

Recent PRs without prefix:
- #5872
- #5845
- #5844

Last PRs with prefix:
- #5822
- #5818

Explicitly set `commitMessagePrefix` so the prefix is no longer dependent on
upstream preset defaults.
