### PR TITLE
claude-control 0.14.0

### DIFF
--- a/Casks/c/claude-control.rb
+++ b/Casks/c/claude-control.rb
@@ -1,15 +1,21 @@
 cask "claude-control" do
   arch arm: "-arm64", intel: ""
 
-  version "0.8.3"
-  sha256 arm:   "10c29e4236a31114af36be98e7668d0e6c60af516a14deef8d6e351358cb98bb",
-         intel: "8d5584f96e1dc0bcc56fb42e4f08e1f457f494d1b80a673adcd7d4406f5ef06b"
+  version "0.14.0"
+  sha256 arm:   "a47045de15614778741335fd2bf000e26d8e40c7728a655a5aa3981d11474a35",
+         intel: "3f133fb4edf8bb1065b902fc57049f7edf9c5bd724dd11890526098d814180db"
 
   url "https://github.com/sverrirsig/claude-control/releases/download/v#{version}/Claude.Control-#{version}#{arch}.dmg"
   name "Claude Control"
   desc "Desktop dashboard for monitoring and managing Claude Code sessions"
   homepage "https://github.com/sverrirsig/claude-control"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
   depends_on macos: ">= :monterey"
 
   app "Claude Control.app"


### PR DESCRIPTION
- Bump 0.8.3 → 0.14.0
- Add livecheck (github_latest)
- Add auto_updates (Electron/Squirrel)