### PR TITLE
cleanboard: fix zap stanza, add livecheck and depends_on

### DIFF
--- a/Casks/c/cleanboard.rb
+++ b/Casks/c/cleanboard.rb
@@ -8,11 +8,19 @@ cask "cleanboard" do
   desc "Lightweight app that removes formatting from copied text by hitting copy twice"
   homepage "https://cleanboard.app/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
   app "CleanBoard.app"
 
   zap trash: [
-    "~/Library/Application Support/CleanBoard",
-    "~/Library/Caches/com.cleanboard.app",
-    "~/Library/Preferences/com.cleanboard.app.plist",
+    "~/Library/Application Support/com.tompod.cleanboard",
+    "~/Library/HTTPStorages/com.tompod.cleanboard",
+    "~/Library/Preferences/com.tompod.cleanboard.plist",
+    "~/Library/Preferences/com.tompod.cleanboard.revenuecat.etags.plist",
   ]
 end


### PR DESCRIPTION
- Fix zap stanza (wrong bundle ID: com.cleanboard.app → com.tompod.cleanboard)
- Add livecheck (github_latest)
- Add depends_on macos catalina (LSMinimumSystemVersion 10.15)