### PR TITLE
renovate: ignore formula updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,12 @@
     'dependencies',
     'renovate',
   ],
+  // Renovate's Homebrew manager currently only matches Formula/**. Ignore
+  // formulae to avoid duplicating autobump-formula.yml, but leave Casks/**
+  // visible in case Renovate adds native cask support later.
+  ignorePaths: [
+    'Formula/**',
+  ],
   vulnerabilityAlerts: {
     enabled: true,
     labels: [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,6 +364,11 @@ For recurring maintenance work in this tap, prefer the repo-local helpers under 
 
 If a helper does not match the job cleanly, fall back to the explicit `brew`/`gh` commands in this document instead of forcing the helper into a workflow it was not built for.
 
+## Renovate And Autobump Ownership
+
+- Formula version bumps are owned by [autobump-formula.yml](.github/workflows/autobump-formula.yml). Keep Renovate from opening `Formula/**` update PRs; if Renovate proposes a formula update, close it as a duplicate of the BrewTestBot/autobump PR or update [.github/renovate.json5](.github/renovate.json5).
+- Do not add `Casks/**` to Renovate ignore rules just to mirror `Formula/**`. Renovate's current Homebrew manager does not scan casks, and leaving `Casks/**` visible preserves future native cask support. Cask bumps remain owned by [autobump-cask.yml](.github/workflows/autobump-cask.yml) unless the repo intentionally changes policy.
+
 ## CI Failures
 
 - Reproduce failures locally before debugging


### PR DESCRIPTION
## Summary

- Ignore `Formula/**` in Renovate so formula version bumps stay owned by `autobump-formula.yml`.
- Document the Renovate/autobump ownership split in `AGENTS.md`, including why `Casks/**` is intentionally not ignored.

## Validation

- `git diff --check`
- `npx --yes --package=renovate@43.141.3 renovate-config-validator .github/renovate.json5`

AI assisted with the config/docs patch. Manual verification confirmed Renovate's Homebrew manager currently matches formula files and the version-matched Renovate validator passes.


closes #6384 