### PR TITLE
fakecloud 0.13.0 (new formula)

### DIFF
--- a/Formula/f/fakecloud.rb
+++ b/Formula/f/fakecloud.rb
@@ -8,7 +8,12 @@ class Fakecloud < Formula
   license "AGPL-3.0-or-later"
   head "https://github.com/faiscadev/fakecloud.git", branch: "main"
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
+
+  on_linux do
+    depends_on "openssl@3"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args(path: "crates/fakecloud-server")

--- a/Formula/f/fakecloud.rb
+++ b/Formula/f/fakecloud.rb
@@ -13,6 +13,7 @@ class Fakecloud < Formula
 
   on_linux do
     depends_on "openssl@3"
+    depends_on "zlib-ng-compat"
   end
 
   def install

--- a/Formula/f/fakecloud.rb
+++ b/Formula/f/fakecloud.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Fakecloud < Formula
+  desc "Free, open-source local AWS cloud emulator for integration testing"
+  homepage "https://github.com/faiscadev/fakecloud"
+  url "https://github.com/faiscadev/fakecloud/archive/refs/tags/v0.13.0.tar.gz"
+  sha256 "fec5304b58e1c1e880d777abc5817f46851dcdbedee27044a87524bb0756a78e"
+  license "AGPL-3.0-or-later"
+  head "https://github.com/faiscadev/fakecloud.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/fakecloud-server")
+  end
+
+  service do
+    run [opt_bin/"fakecloud"]
+    keep_alive true
+  end
+
+  test do
+    port = free_port
+    fork do
+      exec bin/"fakecloud", "--addr", "127.0.0.1:#{port}"
+    end
+    sleep 3
+
+    output = shell_output("curl -s http://127.0.0.1:#{port}/_fakecloud/health 2>&1")
+    assert_match "ok", output.downcase
+
+    assert_match version.to_s, shell_output("#{bin}/fakecloud --version")
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS.

Free, open-source local AWS cloud emulator for integration testing (LocalStack alternative). Rust binary built from source.