### PR TITLE
agent-sessions 3.6.4 (new cask)

### DIFF
--- a/Casks/a/agent-sessions.rb
+++ b/Casks/a/agent-sessions.rb
@@ -1,0 +1,24 @@
+cask "agent-sessions" do
+  version "3.6.4"
+  sha256 "a32780803662d1d46e960f5ef01af8dae2e3a663bb07b4b327eaf0b93e37da41"
+
+  url "https://github.com/jazzyalex/agent-sessions/releases/download/v#{version}/AgentSessions-#{version}.dmg"
+  name "AgentSessions"
+  desc "Session browser, analytics, and rate-limit tracker for AI coding agents"
+  homepage "https://github.com/jazzyalex/agent-sessions"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "AgentSessions.app"
+
+  zap trash: [
+    "~/Library/Application Support/AgentSessions",
+    "~/Library/Preferences/com.jazzyalex.AgentSessions.plist",
+  ]
+end


### PR DESCRIPTION
New cask for [AgentSessions](https://github.com/jazzyalex/agent-sessions) - session browser, analytics, and rate-limit tracker for AI coding agents (Claude Code, Codex CLI, Gemini CLI, etc.).