### PR TITLE
emplace: project migrated to codeberg

### DIFF
--- a/Formula/e/emplace.rb
+++ b/Formula/e/emplace.rb
@@ -1,10 +1,10 @@
 class Emplace < Formula
   desc "Synchronize installed packages on multiple machines"
-  homepage "https://github.com/tversteeg/emplace"
-  url "https://github.com/tversteeg/emplace/archive/refs/tags/v1.6.0.tar.gz"
-  sha256 "c50c085e75bb0c4ad6fb5d5baabf94bc74080499d74fd7072fee9b17041e8586"
+  homepage "https://codeberg.org/fosk/emplace"
+  url "https://codeberg.org/fosk/emplace/archive/v1.6.0.tar.gz"
+  sha256 "cf40269689b5b683fdad2dafb401ebf3eff43e4f6dab113849a3d28563c39d00"
   license "AGPL-3.0-or-later"
-  head "https://github.com/tversteeg/emplace.git", branch: "master"
+  head "https://codeberg.org/fosk/emplace.git", branch: "master"
 
   bottle do
     root_url "https://ghcr.io/v2/chenrui333/tap"
@@ -16,10 +16,10 @@ class Emplace < Formula
 
   depends_on "rust" => :build
 
-  # time crate patch for rust 1.80+, upstream pr ref, https://github.com/tversteeg/emplace/pull/397
+  # time crate patch for rust 1.80+, upstream pr ref, https://codeberg.org/fosk/emplace/pull/397
   patch do
-    url "https://github.com/tversteeg/emplace/commit/ea39f5826f6d0501aa3073f620b8a764900d3dc5.patch?full_index=1"
-    sha256 "d203be4401956ccdf38de75c503ae215a91e4ea8a1be0aed1de07ef248a67f01"
+    url "https://codeberg.org/fosk/emplace/commit/ea39f5826f6d0501aa3073f620b8a764900d3dc5.patch?full_index=1"
+    sha256 "2b040ef1b5cfb96aefa8c17def110562dc4fa280c1e7fa764162c7d3568c6d30"
   end
 
   def install

--- a/formula-status/formula-status.md
+++ b/formula-status/formula-status.md
@@ -314,7 +314,7 @@ Total formulas: 876
 | oxicord | Lightweight, secure Discord terminal client written in Rust | 288 | 10 | 2026-03-05 | 2026-02-23 | GPL-3.0-only | ✓ | - | [link](https://github.com/linuxmobile/oxicord) |
 | protoc-gen-lint | Lint .proto files for style violations | 287 | 16 | 2024-12-23 | 2022-11-08 | MIT | ✓ | - | [link](https://github.com/ckaznocha/protoc-gen-lint) |
 | pyink | Python formatter, forked from Black with a few different for... | 287 | 18 | 2026-01-02 | 2025-01-10 | MIT | ✓ | - | [link](https://github.com/google/pyink) |
-| emplace | Synchronize installed packages on multiple machines | 283 | 27 | 2026-02-16 | 2024-05-25 | AGPL-3.0-or-later | ✓ | - | [link](https://github.com/tversteeg/emplace) |
+| emplace | Synchronize installed packages on multiple machines | 283 | 27 | 2026-02-16 | 2024-05-25 | AGPL-3.0-or-later | ✓ | - | [link](https://codeberg.org/fosk/emplace) |
 | oyo | Step-through diff viewer | 282 | 5 | 2026-03-01 | 2026-02-15 | MIT | ✓ | - | [link](https://github.com/ahkohd/oyo) |
 | resto | Send pretty HTTP & API requests with TUI | 282 | 13 | 2024-07-19 | 2022-01-03 | MIT | ✓ | - | [link](https://github.com/abdfnx/resto) |
 | jiq | Interactive JSON query tool with real-time output and AI ass... | 280 | 3 | 2026-02-24 | 2026-02-20 | Apache-2.0 | ✓ | - | [link](https://github.com/bellicose100xp/jiq) |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrate `emplace` from GitHub to Codeberg across the tap. Updated formula homepage, source tarball URL and sha256, `head` repo, and patch URL and sha256, and switched the `formula-status` link to Codeberg.

<sup>Written for commit 229a1c732dca08cd85971bdde34ec8546fc1e5ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

