### PR TITLE
mockgen 0.6.0 (new formula)

### DIFF
--- a/Formula/m/mockgen.rb
+++ b/Formula/m/mockgen.rb
@@ -1,0 +1,35 @@
+class Mockgen < Formula
+  desc "Mock code generator for Go interfaces"
+  homepage "https://github.com/uber-go/mock"
+  url "https://github.com/uber-go/mock/archive/refs/tags/v0.6.0.tar.gz"
+  sha256 "e315da02f11069f4e9688054cf8dba86535318ea28ab7a2fe144c5e6a859e329"
+  license "Apache-2.0"
+  head "https://github.com/uber-go/mock.git", branch: "main"
+
+  depends_on "go" => [:build, :test]
+
+  def install
+    cd "mockgen" do
+      system "go", "build", *std_go_args(ldflags: "-s -w")
+    end
+  end
+
+  test do
+    ENV["GOPATH"] = testpath/"go"
+    src = testpath/"go/src/greeter"
+    src.mkpath
+
+    (src/"greeter.go").write <<~GO
+      package greeter
+
+      type Greeter interface {
+        Greet(name string) string
+      }
+    GO
+
+    cd src do
+      output = shell_output("#{bin}/mockgen -source greeter.go -package greeter")
+      assert_match "MockGreeter", output
+    end
+  end
+end


### PR DESCRIPTION
Mock code generator for Go interfaces from uber-go/mock.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Homebrew formula for `mockgen` v0.6.0. Builds the `mockgen` binary with Go and tests that running `mockgen` on an interface emits `MockGreeter`.

<sup>Written for commit 51515e54948ac21773a61017d06f0821eaca1940. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

