### PR TITLE
nanobrew 0.1.192 (new formula)

### DIFF
--- a/Formula/n/nanobrew.rb
+++ b/Formula/n/nanobrew.rb
@@ -1,0 +1,38 @@
+class Nanobrew < Formula
+  desc "Fast package manager for macOS and Linux"
+  homepage "https://nanobrew.trilok.ai"
+  url "https://github.com/justrach/nanobrew/archive/refs/tags/v0.1.192.tar.gz"
+  sha256 "2d034c2d291e8b298a01072b3920ba576ce57afa45bac2ff28e317eb3a7375bc"
+  license "Apache-2.0"
+  head "https://github.com/justrach/nanobrew.git", branch: "main"
+
+  depends_on "zig" => :build
+
+  conflicts_with "nb", because: "both install `nb` binaries"
+
+  def install
+    # Native Linux builds use std.c APIs, so link libc like upstream's Linux cross-compile targets.
+    inreplace "build.zig",
+              "    b.installArtifact(exe);",
+              "    if (target.result.os.tag == .linux) exe.root_module.link_libc = true;\n    b.installArtifact(exe);"
+
+    zig = Formula["zig"].opt_bin/"zig"
+    system zig, "build", *std_zig_args
+    generate_completions_from_executable(bin/"nb", "completions")
+  end
+
+  def caveats
+    <<~EOS
+      Run `sudo nb init` before installing packages with nanobrew.
+    EOS
+  end
+
+  test do
+    output = shell_output("#{bin}/nb help")
+    assert_match "nanobrew", output
+    assert_match version.to_s, output
+    assert_match "nb <command> [arguments]", output
+
+    assert_match "compdef _nb nb", shell_output("#{bin}/nb completions zsh")
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.4.1.

Adds nanobrew 0.1.192 as a source-built Zig formula with shell completions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `nanobrew` 0.1.192 as a new Homebrew formula that builds from source with `zig`. Installs the `nb` CLI with shell completions and a setup caveat.

- **New Features**
  - Builds from source with `zig` and links libc on Linux; includes `head` on `main`.
  - Installs shell completions via `nb completions`.
  - Adds caveat: run `sudo nb init` before installing packages.
  - Declares conflict with `nb` (both provide `nb`).

<sup>Written for commit 8a62d594ce014f4c5893b85866193b388f948fdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

