### PR TITLE
claude-agent-acp 0.22.2 (new formula)

### DIFF
--- a/Formula/c/claude-agent-acp.rb
+++ b/Formula/c/claude-agent-acp.rb
@@ -1,0 +1,65 @@
+class ClaudeAgentAcp < Formula
+  desc "Use Claude Code from any ACP client such as Zed!"
+  homepage "https://github.com/zed-industries/claude-agent-acp"
+  url "https://registry.npmjs.org/@zed-industries/claude-agent-acp/-/claude-agent-acp-0.22.2.tgz"
+  sha256 "780ff4aa3dac8f120abeec1f3b3a575a56c25b9647441c52090bf0b1f3a265ea"
+  license "Apache-2.0"
+  head "https://github.com/zed-industries/claude-agent-acp.git", branch: "main"
+
+  depends_on "node"
+  depends_on "ripgrep"
+
+  def install
+    system "npm", "install", *std_npm_args
+    vendor_dir = libexec/"lib/node_modules/@zed-industries/claude-agent-acp" /
+                 "node_modules/@anthropic-ai/claude-agent-sdk/vendor"
+
+    %w[ripgrep audio-capture tree-sitter-bash].each do |dep|
+      dep_dir = vendor_dir/dep
+      rm_r dep_dir
+    end
+
+    arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
+    ripgrep_platform = "#{arch}-#{OS.kernel_name.downcase}"
+    ripgrep_vendor_dir = vendor_dir/"ripgrep"
+    platform_dir = ripgrep_vendor_dir/ripgrep_platform
+    platform_dir.mkpath
+    ln_s Formula["ripgrep"].opt_bin/"rg", platform_dir/"rg"
+    bin.install_symlink libexec/"bin/claude-agent-acp"
+  end
+
+  test do
+    require "open3"
+    require "timeout"
+
+    json = <<~JSON
+      {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}
+    JSON
+
+    Open3.popen3(bin/"claude-agent-acp") do |stdin, stdout, stderr, wait_thr|
+      stdin.puts json
+      stdin.flush
+
+      output = +""
+      Timeout.timeout(30) do
+        until output.include?("\"protocolVersion\":1")
+          ready = IO.select([stdout, stderr])
+          ready[0].each do |io|
+            chunk = io.readpartial(1024)
+            output << chunk if io == stdout
+          end
+        end
+      end
+      assert_match "\"protocolVersion\":1", output
+    ensure
+      stdin.close unless stdin.closed?
+      if wait_thr&.alive?
+        begin
+          Process.kill("TERM", wait_thr.pid)
+        rescue Errno::ESRCH
+          # Process already exited between alive? check and kill.
+        end
+      end
+    end
+  end
+end

--- a/Formula/c/claude-agent-acp.rb
+++ b/Formula/c/claude-agent-acp.rb
@@ -36,7 +36,7 @@ class ClaudeAgentAcp < Formula
       {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}
     JSON
 
-    Open3.popen3(bin/"claude-agent-acp") do |stdin, stdout, stderr, wait_thr|
+    Open3.popen3(bin/"claude-agent-acp") do |stdin, stdout, stderr, wait_thread|
       stdin.puts json
       stdin.flush
 
@@ -53,9 +53,9 @@ class ClaudeAgentAcp < Formula
       assert_match "\"protocolVersion\":1", output
     ensure
       stdin.close unless stdin.closed?
-      if wait_thr&.alive?
+      if wait_thread&.alive?
         begin
-          Process.kill("TERM", wait_thr.pid)
+          Process.kill("TERM", wait_thread.pid)
         rescue Errno::ESRCH
           # Process already exited between alive? check and kill.
         end


### PR DESCRIPTION
Built and tested locally on macOS.

Backfills claude-agent-acp after Homebrew/core removed it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.



References:
- #6647
- Homebrew/homebrew-core#273635
