### PR TITLE
tdd-guard 1.1.0 (new formula)

### DIFF
--- a/Formula/t/tdd-guard.rb
+++ b/Formula/t/tdd-guard.rb
@@ -1,0 +1,42 @@
+class TddGuard < Formula
+  desc "Automated TDD enforcement for Claude Code"
+  homepage "https://github.com/nizos/tdd-guard"
+  url "https://registry.npmjs.org/tdd-guard/-/tdd-guard-1.1.0.tgz"
+  sha256 "f9da65d258979704097f6646190473a31080e05909ab54c814b8d902a8938087"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+
+    # Remove incompatible pre-built binaries
+    node_modules = libexec/"lib/node_modules/tdd-guard/node_modules"
+    ripgrep_vendor_dir = node_modules/"@anthropic-ai/claude-agent-sdk/vendor/ripgrep"
+    rm_r(ripgrep_vendor_dir)
+  end
+
+  test do
+    (testpath/".env").write <<~EOS
+      MODEL_TYPE=claude_cli
+      USE_SYSTEM_CLAUDE=true
+      LINTER_TYPE=eslint
+    EOS
+
+    input = <<~JSON
+      {
+        "event": "PreToolUse",
+        "tool_use": {
+          "name": "Write",
+          "input": {
+            "path": "example.py",
+            "contents": "print('hello')"
+          }
+        }
+      }
+    JSON
+
+    assert_match "reason", pipe_output(bin/"tdd-guard", input, 0)
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -166,7 +166,6 @@
   "sttr": "homebrew/core",
   "style-dictionary": "homebrew/core",
   "supabase-mcp-server": "homebrew/core",
-  "tdd-guard": "homebrew/core",
   "termsvg": "homebrew-core",
   "terraform-cleaner": "homebrew/core",
   "terraform-iam-policy-validator": "homebrew/core",


### PR DESCRIPTION
Built and tested locally on macOS.

Backfills tdd-guard after Homebrew/core removed it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Also removes the stale tap migration back to Homebrew/core so the tap formula resolves.

References:
- #6647
- Homebrew/homebrew-core#273635
