### PR TITLE
sonarqube-lts 9.9.8.100196 (new formula)

### DIFF
--- a/Formula/s/sonarqube-lts.rb
+++ b/Formula/s/sonarqube-lts.rb
@@ -1,0 +1,38 @@
+class SonarqubeLts < Formula
+  desc "Manage code quality"
+  homepage "https://www.sonarqube.org/"
+  url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-9.9.8.100196.zip"
+  sha256 "07d9100c95e5c19f1785c0e9ffc7c8973ce3069a568d2500146a5111b6e966cd"
+  license "LGPL-3.0-or-later"
+
+  # Upstream no longer provides a Community Build for LTA releases.
+  # See: https://www.sonarsource.com/blog/better-free-sonarqube-experience/
+  deprecate! date: "2025-03-19", because: :deprecated_upstream
+
+  depends_on "openjdk@17"
+
+  def install
+    # Delete native bin directories for other systems
+    remove, keep = if OS.mac?
+      ["linux", "macosx-universal"]
+    else
+      ["macosx", "linux-x86"]
+    end
+
+    rm_r(Dir["bin/{#{remove},windows}-*"])
+
+    libexec.install Dir["*"]
+
+    (bin/"sonar").write_env_script libexec/"bin/#{keep}-64/sonar.sh",
+      Language::Java.overridable_java_home_env("17")
+  end
+
+  service do
+    run [opt_bin/"sonar", "start"]
+  end
+
+  test do
+    ENV["SONAR_JAVA_PATH"] = Formula["openjdk@17"].opt_bin/"java"
+    assert_match "SonarQube", shell_output("#{bin}/sonar status", 1)
+  end
+end


### PR DESCRIPTION
Backfills sonarqube-lts after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: restored 9.9.8.100196 from the Homebrew/core removal point. Upstream no longer provides a Community Build for LTA releases per the formula comment, so this intentionally preserves the removed formula baseline.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#210225
