### PR TITLE
iozone 3_494 (new formula)

### DIFF
--- a/Formula/i/iozone.rb
+++ b/Formula/i/iozone.rb
@@ -1,0 +1,33 @@
+class Iozone < Formula
+  desc "File system benchmark tool"
+  homepage "https://www.iozone.org/"
+  url "https://www.iozone.org/src/current/iozone3_494.tgz"
+  sha256 "a36d43831e2829dbc9dc3d5a5a7eb1ca733c9ecc8cbb634022a52928e9b78662"
+  license :cannot_represent
+
+  livecheck do
+    url "https://www.iozone.org/src/current/"
+    regex(/href=.*?iozone[._-]?v?(\d+(?:[._]\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match&.first&.tr("_", ".") }
+    end
+  end
+
+  def install
+    cd "src/current" do
+      target = OS.mac? ? "macosx" : OS.kernel_name.downcase
+      system "make", "clean"
+      system "make", target, "CC=#{ENV.cc}"
+      bin.install "iozone"
+      pkgshare.install %w[Generate_Graphs client_list gengnuplot.sh gnu3d.dem
+                          gnuplot.dem gnuplotps.dem iozone_visualizer.pl
+                          report.pl]
+    end
+    man1.install "docs/iozone.1"
+  end
+
+  test do
+    assert_match "File size set to 16384 kB",
+      shell_output("#{bin}/iozone -I -s 16M")
+  end
+end


### PR DESCRIPTION
Backfills iozone after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: restored formula version is 3_494; upstream uses a direct current-source URL, so a follow-up manual version check may be useful.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#181127
