### PR TITLE
ec2-ami-tools 1.5.19 (new formula)

### DIFF
--- a/Formula/e/ec2-ami-tools.rb
+++ b/Formula/e/ec2-ami-tools.rb
@@ -1,0 +1,42 @@
+class Ec2AmiTools < Formula
+  desc "Amazon EC2 AMI Tools (helps bundle Amazon Machine Images)"
+  homepage "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-up-ami-tools.html"
+  url "https://ec2-downloads.s3.amazonaws.com/ec2-ami-tools-1.5.19.zip"
+  sha256 "bdda4494bea7d55dfff995459dd4705a953f3365bbc69f03430c796b5cc1dd7f"
+
+  livecheck do
+    url "https://ec2-downloads.s3.amazonaws.com/"
+    regex(/>ec2-ami-tools[._-]v?(\d+(?:\.\d+)+)\.zip</i)
+  end
+
+  depends_on "openjdk"
+
+  uses_from_macos "ruby"
+
+  def install
+    env = { JAVA_HOME: Formula["openjdk"].opt_prefix, EC2_AMITOOL_HOME: libexec }
+    rm Dir["bin/*.cmd"] # Remove Windows versions
+    libexec.install Dir["*"]
+    Pathname.glob("#{libexec}/bin/*") do |file|
+      next if file.directory?
+
+      basename = file.basename
+      next if basename.to_s == "service"
+
+      (bin/basename).write_env_script file, env
+    end
+  end
+
+  def caveats
+    <<~EOS
+      Before you can use these tools you must export some variables to your $SHELL.
+        export AWS_ACCESS_KEY="<Your AWS Access ID>"
+        export AWS_SECRET_KEY="<Your AWS Secret Key>"
+        export AWS_CREDENTIAL_FILE="<Path to the credentials file>"
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output(bin/"ec2-ami-tools-version")
+  end
+end


### PR DESCRIPTION
Backfills ec2-ami-tools after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: restored formula version is 1.5.19 from the Amazon download URL; no simple newer upstream version was identified.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#181069
