### PR TITLE
hyperspec 7.0 (new formula)

### DIFF
--- a/Formula/h/hyperspec.rb
+++ b/Formula/h/hyperspec.rb
@@ -1,0 +1,41 @@
+class Hyperspec < Formula
+  desc "Common Lisp ANSI-standard Hyperspec"
+  homepage "https://www.lispworks.com/documentation/common-lisp.html"
+  url "https://ftp.lispworks.com/pub/software_tools/reference/HyperSpec-7-0.tar.gz"
+  version "7.0"
+  sha256 "1ac1666a9dc697dbd8881262cad4371bcd2e9843108b643e2ea93472ba85d7c3"
+  license :cannot_represent
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?HyperSpec[._-]v?(\d+(?:[.-]\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match&.first&.tr("-", ".") }
+    end
+  end
+
+  def install
+    doc.install Dir["*"]
+  end
+
+  def caveats
+    <<~EOS
+      To use this copy of the HyperSpec with SLIME, put the following in
+      your .emacs initialization file:
+
+      (eval-after-load "slime"
+        '(progn
+           (setq common-lisp-hyperspec-root
+                 "#{HOMEBREW_PREFIX}/share/doc/hyperspec/HyperSpec/")
+           (setq common-lisp-hyperspec-symbol-table
+                 (concat common-lisp-hyperspec-root "Data/Map_Sym.txt"))
+           (setq common-lisp-hyperspec-issuex-table
+                 (concat common-lisp-hyperspec-root "Data/Map_IssX.txt"))))
+
+    EOS
+  end
+
+  test do
+    assert_path_exists doc/"HyperSpec-README.text"
+  end
+end


### PR DESCRIPTION
Backfills hyperspec after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: restored formula version is 7.0; upstream uses a direct LispWorks archive URL, so no automatic latest-version check was applied.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#181058
