### PR TITLE
jsmin 2019-10-30 (new formula)

### DIFF
--- a/Formula/j/jsmin.rb
+++ b/Formula/j/jsmin.rb
@@ -1,0 +1,24 @@
+class Jsmin < Formula
+  desc "Minify JavaScript code"
+  homepage "https://www.crockford.com/javascript/jsmin.html"
+  url "https://github.com/douglascrockford/JSMin/archive/430bfe68dc0823d8c0f92c08d426e517cbc8de5e.tar.gz"
+  version "2019-10-30"
+  sha256 "24e3ad04979ace5d734e38b843f62f0dc832f94f5ba48642da31b4a33ccec9ac"
+  license "JSON"
+
+  # The GitHub repository doesn't contain any tags, so we have to check the
+  # date in the comment at the top of the `jsmin.c` file.
+  livecheck do
+    url "https://raw.githubusercontent.com/douglascrockford/JSMin/master/jsmin.c"
+    regex(/jsmin\.c\s*(\d{4}-\d{1,2}-\d{1,2})/im)
+  end
+
+  def install
+    system ENV.cc, "jsmin.c", "-o", "jsmin"
+    bin.install "jsmin"
+  end
+
+  test do
+    assert_equal "\nvar i=0;", pipe_output(bin/"jsmin", "var i = 0; // comment")
+  end
+end


### PR DESCRIPTION
Backfills jsmin after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: no clearly newer upstream release was identified from GitHub release/tag metadata; restored formula version is 2019-10-30.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#180997
