### PR TITLE
unarj 2.65 (new formula)

### DIFF
--- a/Formula/u/unarj.rb
+++ b/Formula/u/unarj.rb
@@ -1,0 +1,31 @@
+class Unarj < Formula
+  desc "ARJ file archiver"
+  homepage "https://www.arjsoftware.com/files.htm"
+  url "https://src.fedoraproject.org/repo/pkgs/unarj/unarj-2.65.tar.gz/c6fe45db1741f97155c7def322aa74aa/unarj-2.65.tar.gz"
+  sha256 "d7dcc325160af6eb2956f5cb53a002edb2d833e4bb17846669f92ba0ce3f0264"
+  license :cannot_represent
+
+  livecheck do
+    url "https://src.fedoraproject.org/repo/pkgs/unarj/"
+    regex(/href=.*?unarj[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
+
+  resource "testfile" do
+    url "https://s3.amazonaws.com/ARJ/ARJ286.EXE"
+    sha256 "e7823fe46fd971fe57e34eef3105fa365ded1cc4cc8295ca3240500f95841c1f"
+  end
+
+  def install
+    system "make"
+    bin.mkdir
+    system "make", "install", "INSTALLDIR=#{bin}"
+  end
+
+  test do
+    # Ensure that you can extract arj.exe from a sample self-extracting file
+    resource("testfile").stage do
+      system bin/"unarj", "e", "ARJ286.EXE"
+      assert_path_exists Pathname.pwd/"arj.exe"
+    end
+  end
+end


### PR DESCRIPTION
Backfills unarj after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: restored formula version is 2.65 from the Fedora source archive; no simple newer upstream version was identified.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#180988
