### PR TITLE
oysttyer 2.10.0 (new formula)

### DIFF
--- a/Formula/o/oysttyer.rb
+++ b/Formula/o/oysttyer.rb
@@ -1,0 +1,21 @@
+class Oysttyer < Formula
+  desc "Command-line Twitter client"
+  homepage "https://github.com/oysttyer/oysttyer"
+  url "https://github.com/oysttyer/oysttyer/archive/refs/tags/2.10.0.tar.gz"
+  sha256 "3c0ce1c7b112f2db496cc75a6e76c67f1cad956f9e7812819c6ae7a979b2baea"
+  head "https://github.com/oysttyer/oysttyer.git", branch: "master"
+
+  deprecate! date: "2024-01-06", because: :repo_archived
+
+  def install
+    bin.install "oysttyer.pl" => "oysttyer"
+  end
+
+  test do
+    IO.popen(bin/"oysttyer", "r+") do |pipe|
+      assert_equal "-- using SSL for default URLs.", pipe.gets.chomp
+      pipe.puts "^C"
+      pipe.close_write
+    end
+  end
+end


### PR DESCRIPTION
Backfills oysttyer after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: no clearly newer upstream release was identified from GitHub release/tag metadata; restored formula version is 2.10.0.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#180817
