### PR TITLE
frobtads 2.0 (new formula)

### DIFF
--- a/Formula/f/frobtads.rb
+++ b/Formula/f/frobtads.rb
@@ -1,0 +1,34 @@
+class Frobtads < Formula
+  desc "TADS interpreter and compilers"
+  homepage "https://www.tads.org/frobtads.htm"
+  url "https://github.com/realnc/frobtads/releases/download/v2.0/frobtads-2.0.tar.bz2"
+  sha256 "893bd3fd77dfdc8bfe8a96e8d7bfac693da0e4278871f10fe7faa59cc239a090"
+  license :cannot_represent
+
+  depends_on "cmake" => :build
+
+  uses_from_macos "curl"
+  uses_from_macos "ncurses"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"hello.t").write <<~EOS
+      #charset "us-ascii"
+      #include <tads.h>
+
+      main(args) {
+        "Hello, Homebrew!";
+      }
+    EOS
+
+    system bin/"t3make", "hello.t"
+    system bin/"frob", "--no-pause", "hello.t3"
+
+    assert_match version.to_s, shell_output("#{bin}/frob --version")
+  end
+end


### PR DESCRIPTION
Backfills frobtads after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: restored formula version is 2.0 from the GitHub release archive; no simple newer upstream version was identified.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#180798
