### PR TITLE
sflowtool 5.05 (new formula)

### DIFF
--- a/Formula/s/sflowtool.rb
+++ b/Formula/s/sflowtool.rb
@@ -1,0 +1,24 @@
+class Sflowtool < Formula
+  desc "Utilities and scripts for analyzing sFlow data"
+  homepage "https://inmon.com/technology/sflowTools.php"
+  url "https://github.com/sflow/sflowtool/releases/download/v5.05/sflowtool-5.05.tar.gz"
+  sha256 "048c52ead856a23e927fb826ac7663aeaac98795e678792fd6f74c588f90825d"
+
+  resource "scripts" do
+    url "https://inmon.com/bin/sflowutils.tar.gz"
+    sha256 "45f6a0f96bdb6a1780694b9a4ef9bbd2fd719b9f7f3355c6af1427631b311d56"
+  end
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "check"
+    system "make", "install"
+    (prefix/"contrib").install resource("scripts")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/sflowtool -h 2>&1")
+  end
+end


### PR DESCRIPTION
Backfills sflowtool after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: restored formula version is 5.05 from the closed Homebrew/core deletion PR; no local dependency refresh was run.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#58429
