### PR TITLE
sonarqube 25.3.0.104237 (new formula)

### DIFF
--- a/Formula/s/sonarqube.rb
+++ b/Formula/s/sonarqube.rb
@@ -1,0 +1,83 @@
+class Sonarqube < Formula
+  desc "Manage code quality"
+  homepage "https://www.sonarsource.com/products/sonarqube/"
+  url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-25.3.0.104237.zip"
+  sha256 "6eca9241219471c3fca6337bb98ae27360be9a8d810349e053aafb6e596cd90d"
+  license "LGPL-3.0-or-later"
+
+  livecheck do
+    url "https://www.sonarsource.com/page-data/products/sonarqube/downloads/success-download-community-edition/page-data.json"
+    regex(/sonarqube[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
+  depends_on "openjdk@17"
+
+  def install
+    inreplace "conf/sonar.properties" do |s|
+      # Write log/data/temp files outside of installation directory
+      s.sub!(/^#sonar\.path\.data=.*/, "sonar.path.data=#{var}/sonarqube/data")
+      s.sub!(/^#sonar\.path\.logs=.*/, "sonar.path.logs=#{var}/sonarqube/logs")
+      s.sub!(/^#sonar\.path\.temp=.*/, "sonar.path.temp=#{var}/sonarqube/temp")
+    end
+
+    libexec.install Dir["*"]
+    (libexec/"extensions/downloads").mkpath
+
+    env = Language::Java.overridable_java_home_env("17")
+    env["PATH"] = "$JAVA_HOME/bin:$PATH"
+    env["PIDDIR"] = var/"run"
+    platform = OS.mac? ? "macosx-universal-64" : "linux-x86-64"
+    (bin/"sonar").write_env_script libexec/"bin"/platform/"sonar.sh", env
+
+    # remove non-native architecture pre-built binaries
+    os = OS.kernel_name.downcase
+    arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
+    (libexec/"elasticsearch/lib/platform").glob("*").each do |dir|
+      rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}"
+    end
+  end
+
+  def post_install
+    (var/"run").mkpath
+    (var/"sonarqube/logs").mkpath
+  end
+
+  def caveats
+    <<~EOS
+      Data: #{var}/sonarqube/data
+      Logs: #{var}/sonarqube/logs
+      Temp: #{var}/sonarqube/temp
+    EOS
+  end
+
+  service do
+    run [opt_bin/"sonar", "console"]
+    keep_alive true
+  end
+
+  test do
+    port = free_port
+    ENV["SONAR_WEB_PORT"] = port.to_s
+    ENV["SONAR_EMBEDDEDDATABASE_PORT"] = free_port.to_s
+    ENV["SONAR_SEARCH_PORT"] = free_port.to_s
+    ENV["SONAR_PATH_DATA"] = testpath/"data"
+    ENV["SONAR_PATH_LOGS"] = testpath/"logs"
+    ENV["SONAR_PATH_TEMP"] = testpath/"temp"
+    ENV["SONAR_TELEMETRY_ENABLE"] = "false"
+
+    # Sonar uses `ps | grep` to verify server is running, but output is truncated to COLUMNS
+    # See https://github.com/Homebrew/homebrew-core/pull/133887#issuecomment-1679907729
+    ENV.delete "COLUMNS"
+
+    assert_match(/SonarQube.* is not running/, shell_output("#{bin}/sonar status", 1))
+    pid = fork { exec bin/"sonar", "console" }
+    begin
+      sleep 15
+      output = shell_output("#{bin}/sonar status")
+      assert_match(/SonarQube is running \([0-9]*?\)/, output)
+    ensure
+      Process.kill 9, pid
+      Process.wait pid
+    end
+  end
+end


### PR DESCRIPTION
Backfills sonarqube after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: restored formula version is 25.3.0.104237 from the Homebrew/core removal point; SonarSource download metadata should be reviewed in follow-up if we want the newest upstream build.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#210225
