### PR TITLE
unrar 6.0.2 (new formula)

### DIFF
--- a/Formula/u/unrar.rb
+++ b/Formula/u/unrar.rb
@@ -1,0 +1,41 @@
+class Unrar < Formula
+  desc "Extract, view, and test RAR archives"
+  homepage "https://www.rarlab.com/"
+  url "https://www.rarlab.com/rar/unrarsrc-6.0.2.tar.gz"
+  sha256 "81bf188333f89c976780a477af27f651f54aa7da9312303d8d1a804696d3edd3"
+  license "UnRAR"
+
+  livecheck do
+    url "https://www.rarlab.com/rar_add.htm"
+    regex(/href=.*?unrarsrc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  def install
+    inreplace "makefile", "libunrar.so", "libunrar.dylib" if OS.mac?
+
+    system "make"
+    bin.install "unrar"
+
+    # Explicitly clean up for the library build to avoid an issue with an
+    # apparent implicit clean which confuses the dependencies.
+    system "make", "clean"
+    system "make", "lib"
+    lib.install shared_library("libunrar")
+  end
+
+  test do
+    contentpath = "directory/file.txt"
+    rarpath = testpath/"archive.rar"
+    data = [
+      "UmFyIRoHAM+QcwAADQAAAAAAAACaCHQggDIACQAAAAkAAAADtPej1LZwZE",
+      # spellchecker:ignore-next-line
+      "QUMBIApIEAAGRpcmVjdG9yeVxmaWxlLnR4dEhvbWVicmV3CsQ9ewBABwA=",
+    ].join
+
+    rarpath.write data.unpack1("m")
+    assert_equal contentpath, shell_output("#{bin}/unrar lb #{rarpath}").strip
+
+    system bin/"unrar", "x", rarpath, testpath
+    assert_equal "Homebrew\n", (testpath/contentpath).read
+  end
+end


### PR DESCRIPTION
Backfills unrar after Homebrew/core removed or rejected it under its license policy. This tap PR makes it available for users who explicitly opt into chenrui333/homebrew-tap; users should review upstream licensing and terms before installing or using it.

Static notes:
- Removed the old Homebrew/core bottle block where one existed so this tap can rebuild it.
- Static check: restored formula version is 6.0.2 from the Homebrew/core removal point; upstream RARLab sources appear newer, so a follow-up version/dependency refresh is likely needed.
- No local brew install/test/audit was run; tap CI is the validation path.

References:
- #6647
- Homebrew/homebrew-core#66609
