### PR TITLE
caveman-shrink 0.1.0 (new formula)

### DIFF
--- a/Formula/c/caveman-shrink.rb
+++ b/Formula/c/caveman-shrink.rb
@@ -1,0 +1,37 @@
+class CavemanShrink < Formula
+  desc "MCP proxy that compresses prose fields in tool catalogs"
+  homepage "https://github.com/JuliusBrussee/caveman"
+  url "https://registry.npmjs.org/caveman-shrink/-/caveman-shrink-0.1.0.tgz"
+  sha256 "2b40eccce35fe8ce145e6c02fe02d192235ab655cb3614244ca98188c04f87a7"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match "missing upstream command",
+                 shell_output("#{bin}/caveman-shrink 2>&1", 2)
+
+    (testpath/"fake.js").write <<~JS
+      const msg = {
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          tools: [{
+            name: "demo",
+            description: "Please just fetch the user data"
+          }]
+        }
+      };
+      process.stdout.write(JSON.stringify(msg) + "\\n");
+    JS
+
+    output = shell_output("#{bin}/caveman-shrink node #{testpath}/fake.js")
+    refute_match(/please/i, output)
+    assert_match "demo", output
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS.

New formula for [caveman-shrink](https://github.com/JuliusBrussee/caveman/tree/main/mcp-servers/caveman-shrink) — MCP stdio proxy that compresses prose fields (`description`, etc.) in `tools/list`/`prompts/list`/`resources/list` responses to cut context tokens without changing tool semantics. Pure Node, zero runtime deps.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new Homebrew formula for `caveman-shrink` 0.1.0, a Node-based MCP stdio proxy that compresses prose in `tools/list`, `prompts/list`, and `resources/list` responses to reduce token usage.

Installs via `npm`, depends on `node`, and includes tests for missing upstream handling and that descriptions are compressed while tool names remain intact.

<sup>Written for commit 6e01a32b00225f6beda0fd4df7a97addc7f2153c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

