### PR TITLE
unifly 0.9.1 (new formula)

### DIFF
--- a/Formula/u/unifly.rb
+++ b/Formula/u/unifly.rb
@@ -2,7 +2,7 @@ class Unifly < Formula
   desc "CLI/TUI for UniFi network controller management"
   homepage "https://github.com/hyperb1iss/unifly"
   url "https://github.com/hyperb1iss/unifly/archive/refs/tags/v0.9.1.tar.gz"
-  sha256 "7c0742ca5a9b6a8e80ebcd7741acdc86ce23bf3d48eabbc03fd387b25ee4b1b9"
+  sha256 "34a5c73a548270f670b9458f07da3ba1a94f1b9c31831fd4c433d6e01d561330"
   license "Apache-2.0"
   head "https://github.com/hyperb1iss/unifly.git", branch: "main"
 

--- a/Formula/u/unifly.rb
+++ b/Formula/u/unifly.rb
@@ -1,0 +1,18 @@
+class Unifly < Formula
+  desc "CLI/TUI for UniFi network controller management"
+  homepage "https://github.com/hyperb1iss/unifly"
+  url "https://github.com/hyperb1iss/unifly/archive/refs/tags/v0.9.1.tar.gz"
+  sha256 "7c0742ca5a9b6a8e80ebcd7741acdc86ce23bf3d48eabbc03fd387b25ee4b1b9"
+  license "Apache-2.0"
+  head "https://github.com/hyperb1iss/unifly.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/unifly")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/unifly --version 2>&1")
+  end
+end

--- a/Formula/u/unifly.rb
+++ b/Formula/u/unifly.rb
@@ -6,6 +6,7 @@ class Unifly < Formula
   license "Apache-2.0"
   head "https://github.com/hyperb1iss/unifly.git", branch: "main"
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   on_linux do

--- a/Formula/u/unifly.rb
+++ b/Formula/u/unifly.rb
@@ -8,6 +8,10 @@ class Unifly < Formula
 
   depends_on "rust" => :build
 
+  on_linux do
+    depends_on "dbus"
+  end
+
   def install
     (buildpath/".cargo/config.toml").delete if OS.linux?
     system "cargo", "install", *std_cargo_args(path: "crates/unifly")

--- a/Formula/u/unifly.rb
+++ b/Formula/u/unifly.rb
@@ -9,6 +9,7 @@ class Unifly < Formula
   depends_on "rust" => :build
 
   def install
+    (buildpath/".cargo/config.toml").delete if OS.linux?
     system "cargo", "install", *std_cargo_args(path: "crates/unifly")
   end
 


### PR DESCRIPTION
Built and tested locally on macOS.

CLI/TUI for UniFi network controller management.