### PR TITLE
cmd: inspect closed superseded updates

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -183,6 +183,7 @@ titles.
 ```bash
 brew close-superseded-prs
 brew close-superseded-prs --formula ministack
+brew close-superseded-prs --closed-days 14
 brew close-superseded-prs --closed-limit 2000
 brew close-superseded-prs --apply
 ```
@@ -190,8 +191,9 @@ brew close-superseded-prs --apply
 ### Notes
 
 - Defaults to dry-run output.
-- Inspects open bump PRs plus recent closed bump PRs, so an older open PR can be superseded by the latest merged or closed update for the same formula.
-- Use `--closed-limit 0` to ignore closed PR history.
+- Inspects open bump PRs plus bump PRs closed in the last 30 days, so an older open PR can be superseded by the latest merged or closed update for the same formula.
+- Use `--closed-days` to tune the date window, or `--closed-days 0` to ignore closed PR history.
+- Use `--closed-limit` as a GitHub API cap for the closed PR lookup.
 - Closes PRs already covered by the version on `main` with a `Superseded by current main...` comment.
 - Keeps the most recently opened bump PR for each formula and closes older open bumps with a fully qualified PR reference.
 - Uses the `superseded` label when applying changes.

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -183,12 +183,15 @@ titles.
 ```bash
 brew close-superseded-prs
 brew close-superseded-prs --formula ministack
+brew close-superseded-prs --closed-limit 2000
 brew close-superseded-prs --apply
 ```
 
 ### Notes
 
 - Defaults to dry-run output.
+- Inspects open bump PRs plus recent closed bump PRs, so an older open PR can be superseded by the latest merged or closed update for the same formula.
+- Use `--closed-limit 0` to ignore closed PR history.
 - Closes PRs already covered by the version on `main` with a `Superseded by current main...` comment.
-- Keeps the most recently opened bump PR for each formula and closes older open bumps with `Superseded by #<pr>`.
+- Keeps the most recently opened bump PR for each formula and closes older open bumps with a fully qualified PR reference.
 - Uses the `superseded` label when applying changes.

--- a/cmd/brew-close-superseded-prs
+++ b/cmd/brew-close-superseded-prs
@@ -16,6 +16,7 @@ TAP_ROOT = File.expand_path("..", __dir__)
 
 options = {
   apply: false,
+  closed_limit: 1000,
   formulas: [],
   limit: 1000,
   repo: ENV.fetch("GH_REPO", DEFAULT_REPO),
@@ -38,6 +39,10 @@ parser = OptionParser.new do |opts|
 
   opts.on("--limit N", Integer, "Maximum open PRs to inspect (default: 1000)") do |limit|
     options[:limit] = limit
+  end
+
+  opts.on("--closed-limit N", Integer, "Maximum closed PRs to inspect as superseding updates (default: 1000)") do |limit|
+    options[:closed_limit] = limit
   end
 
   opts.on("--repo OWNER/REPO", "GitHub repository (default: #{DEFAULT_REPO})") do |repo|
@@ -148,6 +153,10 @@ def created_at(pr)
   Time.parse(pr.fetch("createdAt"))
 end
 
+def pr_sort_key(pr)
+  [created_at(pr), pr.fetch("number")]
+end
+
 def bump_pr(title)
   match = TITLE_PATTERN.match(title)
   return unless match
@@ -156,6 +165,31 @@ def bump_pr(title)
     formula: match[:formula],
     version: match[:version],
   }
+end
+
+def pr_labels(pr)
+  pr.fetch("labels").map { |label| label.fetch("name") }
+end
+
+def bump_prs(prs, formula_filter)
+  prs.each_with_object([]) do |pr, bump_prs|
+    parsed = bump_pr(pr.fetch("title"))
+    next unless parsed
+    next if formula_filter.any? && !formula_filter[parsed[:formula]]
+    next if (pr_labels(pr) & SKIP_LABELS).any?
+    next unless formula_path(parsed[:formula])
+
+    bump_prs << pr.merge(parsed)
+  end
+end
+
+def superseded_body(repo, pr)
+  body = "Superseded by #{repo}##{pr.fetch("number")}"
+  state = pr["state"]
+  if state && state != "OPEN"
+    body += pr["mergedAt"].to_s.empty? ? " (closed)" : " (merged)"
+  end
+  body
 end
 
 def ensure_superseded_label(repo)
@@ -185,29 +219,35 @@ formula_filter = {}
 options[:formulas].each do |formula|
   formula_filter[formula.sub(%r{\Achenrui333/tap/}, "")] = true
 end
-prs = gh_json(
+odie("--limit must be non-negative") if options[:limit].negative?
+odie("--closed-limit must be non-negative") if options[:closed_limit].negative?
+
+open_prs = gh_json(
   "pr", "list",
   "--repo", options[:repo],
   "--state", "open",
   "--limit", options[:limit].to_s,
-  "--json", "number,title,labels,createdAt"
+  "--json", "number,title,labels,createdAt,state,mergedAt"
 )
 
-bump_prs = []
-prs.each do |pr|
-  parsed = bump_pr(pr.fetch("title"))
-  next unless parsed
-  next if formula_filter.any? && !formula_filter[parsed[:formula]]
-
-  labels = pr.fetch("labels").map { |label| label.fetch("name") }
-  next if (labels & SKIP_LABELS).any?
-  next unless formula_path(parsed[:formula])
-
-  bump_prs << pr.merge(parsed)
+closed_prs = if options[:closed_limit].positive?
+  gh_json(
+    "pr", "list",
+    "--repo", options[:repo],
+    "--state", "closed",
+    "--limit", options[:closed_limit].to_s,
+    "--json", "number,title,labels,createdAt,state,mergedAt"
+  )
+else
+  []
 end
 
+open_bump_prs = bump_prs(open_prs, formula_filter)
+all_bump_prs = open_bump_prs + bump_prs(closed_prs, formula_filter)
+all_bump_prs_by_formula = all_bump_prs.group_by { |pr| pr.fetch(:formula) }
+
 closures = []
-bump_prs.group_by { |pr| pr.fetch(:formula) }.each do |formula, formula_prs|
+open_bump_prs.group_by { |pr| pr.fetch(:formula) }.each do |formula, formula_prs|
   current_version = formula_version(formula, options[:repo])
   pending_prs = []
 
@@ -224,20 +264,21 @@ bump_prs.group_by { |pr| pr.fetch(:formula) }.each do |formula, formula_prs|
     end
   end
 
-  next if pending_prs.length <= 1
+  next if pending_prs.empty?
 
-  # Keep the most recently opened bump PR, even if it intentionally rolls back
-  # a bad higher-version bump.
-  keeper = pending_prs.max_by { |pr| [created_at(pr), pr.fetch("number")] }
+  # Keep the most recently opened bump PR, even if it is already merged/closed
+  # or intentionally rolls back a bad higher-version bump.
+  keeper = all_bump_prs_by_formula.fetch(formula).max_by { |pr| pr_sort_key(pr) }
 
   pending_prs.each do |pr|
     next if pr.fetch("number") == keeper.fetch("number")
+    next if (pr_sort_key(keeper) <=> pr_sort_key(pr)).negative?
 
     closures << {
       number: pr.fetch("number"),
       formula: formula,
       version: pr.fetch(:version),
-      body: "Superseded by #{options[:repo]}##{keeper.fetch("number")}",
+      body: superseded_body(options[:repo], keeper),
     }
   end
 end

--- a/cmd/brew-close-superseded-prs
+++ b/cmd/brew-close-superseded-prs
@@ -16,6 +16,7 @@ TAP_ROOT = File.expand_path("..", __dir__)
 
 options = {
   apply: false,
+  closed_days: 30,
   closed_limit: 1000,
   formulas: [],
   limit: 1000,
@@ -43,6 +44,10 @@ parser = OptionParser.new do |opts|
 
   opts.on("--closed-limit N", Integer, "Maximum closed PRs to inspect as superseding updates (default: 1000)") do |limit|
     options[:closed_limit] = limit
+  end
+
+  opts.on("--closed-days N", Integer, "Only inspect PRs closed in the last N days (default: 30; 0 disables closed PR history)") do |days|
+    options[:closed_days] = days
   end
 
   opts.on("--repo OWNER/REPO", "GitHub repository (default: #{DEFAULT_REPO})") do |repo|
@@ -153,6 +158,12 @@ def created_at(pr)
   Time.parse(pr.fetch("createdAt"))
 end
 
+def closed_at(pr)
+  Time.parse(pr.fetch("closedAt"))
+rescue ArgumentError, TypeError
+  nil
+end
+
 def pr_sort_key(pr)
   [created_at(pr), pr.fetch("number")]
 end
@@ -192,6 +203,13 @@ def superseded_body(repo, pr)
   body
 end
 
+def recent_closed_prs(prs, closed_since)
+  prs.select do |pr|
+    closed_at = closed_at(pr)
+    closed_at && closed_at >= closed_since
+  end
+end
+
 def ensure_superseded_label(repo)
   labels = gh_json("label", "list", "--repo", repo, "--limit", "1000", "--json", "name")
   return if labels.any? { |label| label.fetch("name") == SUPERSEDED_LABEL }
@@ -221,6 +239,7 @@ options[:formulas].each do |formula|
 end
 odie("--limit must be non-negative") if options[:limit].negative?
 odie("--closed-limit must be non-negative") if options[:closed_limit].negative?
+odie("--closed-days must be non-negative") if options[:closed_days].negative?
 
 open_prs = gh_json(
   "pr", "list",
@@ -230,14 +249,16 @@ open_prs = gh_json(
   "--json", "number,title,labels,createdAt,state,mergedAt"
 )
 
-closed_prs = if options[:closed_limit].positive?
-  gh_json(
+closed_since = Time.now.utc - (options[:closed_days] * 86_400)
+closed_prs = if options[:closed_limit].positive? && options[:closed_days].positive?
+  recent_closed_prs(gh_json(
     "pr", "list",
     "--repo", options[:repo],
     "--state", "closed",
     "--limit", options[:closed_limit].to_s,
-    "--json", "number,title,labels,createdAt,state,mergedAt"
-  )
+    "--search", "closed:>=#{closed_since.strftime("%Y-%m-%d")}",
+    "--json", "number,title,labels,createdAt,closedAt,state,mergedAt"
+  ), closed_since)
 else
   []
 end


### PR DESCRIPTION
Summary:
- Teach `brew close-superseded-prs` to inspect recent closed bump PRs as superseding updates.
- Add `--closed-days` for date-window semantics, with `--closed-limit` retained as an API cap.
- Document the closed-history behavior and fully qualified PR references.

Notes:
- The existing scheduled workflow runs every 6 hours; this keeps that cadence and gives closed-history lookup a 30-day default window.
- AI assisted with diagnosing and implementing the command update; manual verification covered syntax, dry-run behavior, and a stubbed closed-PR supersession case.
