### PR TITLE
diffyml 1.6.2 (new formula)

### DIFF
--- a/Formula/d/diffyml.rb
+++ b/Formula/d/diffyml.rb
@@ -1,0 +1,25 @@
+class Diffyml < Formula
+  desc "Structural YAML diff tool with Kubernetes intelligence"
+  homepage "https://github.com/szhekpisov/diffyml"
+  url "https://github.com/szhekpisov/diffyml/archive/refs/tags/v1.6.2.tar.gz"
+  sha256 "526eb3eacde2d3db2078318adc61b5dfc4f26dfbdeb841650647b2af10e3cee2"
+  license "MIT"
+  head "https://github.com/szhekpisov/diffyml.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.version=#{version} -X main.commit=#{tap.user} -X main.buildDate=#{time.iso8601}"
+    system "go", "build", *std_go_args(ldflags:)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/diffyml --version")
+
+    (testpath/"from.yml").write "name: old\n"
+    (testpath/"to.yml").write "name: new\n"
+    output = shell_output("#{bin}/diffyml --color never from.yml to.yml")
+    assert_match "Found one difference", output
+    assert_match "+ new", output
+  end
+end


### PR DESCRIPTION
Summary:
- Add diffyml 1.6.2 as a new formula built from source.

References:
- https://github.com/szhekpisov/diffyml/releases/tag/v1.6.2

Notes:
- AI assisted with formula drafting and local validation.
