### PR TITLE
epiq 0.6.20 (new formula)

### DIFF
--- a/Formula/e/epiq.rb
+++ b/Formula/e/epiq.rb
@@ -1,0 +1,19 @@
+class Epiq < Formula
+  desc "Distributed terminal-native issue tracker backed by Git"
+  homepage "https://github.com/ljtn/epiq"
+  url "https://registry.npmjs.org/epiq/-/epiq-0.6.20.tgz"
+  sha256 "e7b1f77920486997a111db3adc45488a0bce85cbc5cc962b7bb0c9514bc7154e"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/epiq --version")
+    assert_match "CLI based issue tracker", shell_output("#{bin}/epiq --help")
+  end
+end


### PR DESCRIPTION
Summary:
- Add epiq 0.6.20 as a new formula.

References:
- https://github.com/ljtn/epiq/releases/tag/v0.6.20
- https://www.npmjs.com/package/epiq/v/0.6.20

Notes:
- AI assisted with formula drafting and local validation.
