### PR TITLE
buffa 0.7.1 (new formula)

### DIFF
--- a/Formula/b/buffa.rb
+++ b/Formula/b/buffa.rb
@@ -1,0 +1,41 @@
+class Buffa < Formula
+  desc "Pure-Rust Protocol Buffers implementation with editions support"
+  homepage "https://github.com/anthropics/buffa"
+  url "https://github.com/anthropics/buffa/archive/refs/tags/v0.7.1.tar.gz"
+  sha256 "511c626799c4b890b44421ec5d8694924a13153c35a68eefa54bd34031a25bbd"
+  license "Apache-2.0"
+  head "https://github.com/anthropics/buffa.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "protobuf"
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "protoc-gen-buffa")
+    system "cargo", "install", *std_cargo_args(path: "protoc-gen-buffa-packaging")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/protoc-gen-buffa --version")
+    assert_match "filter=services", shell_output("#{bin}/protoc-gen-buffa-packaging --help")
+
+    (testpath/"sample.proto").write <<~PROTO
+      syntax = "proto3";
+      package example.v1;
+
+      message Greeting {
+        string message = 1;
+      }
+    PROTO
+
+    (testpath/"gen").mkpath
+    system "protoc",
+           "--plugin=protoc-gen-buffa=#{bin}/protoc-gen-buffa",
+           "--plugin=protoc-gen-buffa-packaging=#{bin}/protoc-gen-buffa-packaging",
+           "--buffa_out=gen",
+           "--buffa-packaging_out=gen",
+           "sample.proto"
+
+    assert_match "pub struct Greeting", (testpath/"gen/sample.rs").read
+    assert_match "pub mod example", (testpath/"gen/mod.rs").read
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS.

Adds `buffa`'s protoc plugin binaries:
- `protoc-gen-buffa`
- `protoc-gen-buffa-packaging`

AI-assisted: drafted the formula and validation flow.
Manual verification: source build, `brew test`, `brew linkage --test`, `brew audit --new`, and `brew style`.
