### PR TITLE
bufisk 0.1.0 (new formula)

### DIFF
--- a/Formula/b/bufisk.rb
+++ b/Formula/b/bufisk.rb
@@ -1,0 +1,19 @@
+class Bufisk < Formula
+  desc "User-friendly launcher for Buf"
+  homepage "https://github.com/bufbuild/bufisk"
+  url "https://github.com/bufbuild/bufisk/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "ad4ee8d36da378fb0ea492d291d50851d4b68dea1f30f9ad54633a7b24564ecf"
+  license "Apache-2.0"
+  head "https://github.com/bufbuild/bufisk.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    assert_match "BUF_VERSION not set", shell_output("#{bin}/bufisk 2>&1", 1)
+    assert_match "invalid buf version", shell_output("BUF_VERSION=bad #{bin}/bufisk 2>&1", 1)
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS.

Adds `bufisk`, a launcher that selects and verifies Buf releases based on `BUF_VERSION` or `.bufversion`.

AI-assisted: drafted the formula and validation flow.
Manual verification: source build, `brew test`, `brew linkage --test`, `brew audit --new`, and `brew style`.
