### PR TITLE
clawpatrol 0.2.8 (new formula)

### DIFF
--- a/Formula/c/clawpatrol.rb
+++ b/Formula/c/clawpatrol.rb
@@ -1,0 +1,52 @@
+class Clawpatrol < Formula
+  desc "Security firewall for agents"
+  homepage "https://clawpatrol.dev"
+  url "https://github.com/denoland/clawpatrol/archive/refs/tags/v0.2.8.tar.gz"
+  sha256 "6b434eac675cef2408d7fbc02ae194d23c1a364f6327c9a1d75d23deb854868b"
+  license "MIT"
+  head "https://github.com/denoland/clawpatrol.git", branch: "main"
+
+  depends_on "deno" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["DENO_DIR"] = buildpath/".deno"
+
+    cd "dashboard" do
+      system "deno", "install"
+      system "deno", "task", "build"
+    end
+
+    ldflags = "-s -w -X main.buildVersion=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/clawpatrol"
+
+    pkgshare.install "examples"
+  end
+
+  service do
+    run [opt_bin/"clawpatrol", "gateway", etc/"clawpatrol/gateway.hcl"]
+    keep_alive true
+    working_dir var/"clawpatrol"
+    log_path var/"log/clawpatrol.log"
+    error_log_path var/"log/clawpatrol.log"
+  end
+
+  def caveats
+    <<~EOS
+      Example gateway configs are installed under:
+        #{opt_pkgshare}/examples
+
+      To run the gateway service, create:
+        #{etc}/clawpatrol/gateway.hcl
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/clawpatrol version")
+
+    cp_r pkgshare/"examples", testpath
+    output = shell_output("#{bin}/clawpatrol validate #{testpath}/examples/protocol-https.hcl")
+    assert_match "ok:", output
+    assert_match "1 endpoints across 1 profile(s)", output
+  end
+end


### PR DESCRIPTION
Summary
- Add clawpatrol 0.2.8.

Notes
- Builds the dashboard with Deno and the gateway binary with Go from source.
- Installs example gateway configs and includes a service stanza for clawpatrol gateway.
