### PR TITLE
aic: improve test

### DIFF
--- a/Formula/a/aic.rb
+++ b/Formula/a/aic.rb
@@ -24,6 +24,7 @@ class Aic < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/aic --version")
     # Avoid network-dependent changelog lookups in CI.
-    assert_match "Usage:", shell_output("#{bin}/aic claude --help")
+    output = shell_output("#{bin}/aic not-a-real-assistant 2>&1", 1)
+    assert_match "unknown command", output
   end
 end


### PR DESCRIPTION
Built and tested locally.

Improves the formula test coverage by replacing a subcommand help-output assertion with deterministic invalid-command behavior while keeping the version assertion.
