### PR TITLE
deface: improve test

### DIFF
--- a/Formula/d/deface.rb
+++ b/Formula/d/deface.rb
@@ -66,6 +66,11 @@ class Deface < Formula
   end
 
   test do
-    system bin/"deface", "--help"
+    require "open3"
+
+    # FIXME: Upstream does not expose a version command; replace this with a version assertion when available.
+    output, status = Open3.capture2e(bin/"deface", "--not-a-real-option")
+    refute_predicate status, :success?
+    assert_match "not-a-real-option", output
   end
 end


### PR DESCRIPTION
CI will validate this branch.

Improves the formula test coverage by replacing a help-output assertion with deterministic binary behavior and a precise version-command FIXME where needed.
