### PR TITLE
discordo: improve test

### DIFF
--- a/Formula/d/discordo.rb
+++ b/Formula/d/discordo.rb
@@ -26,7 +26,11 @@ class Discordo < Formula
   end
 
   test do
-    # discordo is a TUI app, so just verify the binary runs
-    assert_match "config-path", shell_output("#{bin}/discordo --help 2>&1")
+    require "open3"
+
+    # FIXME: Upstream does not expose a version command; replace this with a version assertion when available.
+    output, status = Open3.capture2e(bin/"discordo", "--not-a-real-option")
+    refute_predicate status, :success?
+    assert_match "not-a-real-option", output
   end
 end


### PR DESCRIPTION
CI will validate this branch.

Improves the formula test coverage by replacing a help-output assertion with deterministic binary behavior and a precise version-command FIXME where needed.
