### PR TITLE
macfan: improve test

### DIFF
--- a/Formula/m/macfan.rb
+++ b/Formula/m/macfan.rb
@@ -22,7 +22,11 @@ class Macfan < Formula
   end
 
   test do
-    output = shell_output("#{bin}/macfan --help")
-    assert_match "fan", output
+    require "open3"
+
+    # FIXME: Upstream does not expose a version command; replace this with a version assertion when available.
+    output, status = Open3.capture2e(bin/"macfan", "--not-a-real-option")
+    refute_predicate status, :success?
+    assert_match "not-a-real-option", output
   end
 end


### PR DESCRIPTION
CI will validate this branch.

Improves the formula test coverage by replacing a help/completion-based assertion with deterministic binary behavior and a precise version-command FIXME where needed.
