### PR TITLE
sakimori: improve test

### DIFF
--- a/Formula/s/sakimori.rb
+++ b/Formula/s/sakimori.rb
@@ -22,6 +22,11 @@ class Sakimori < Formula
   end
 
   test do
-    assert_match "sakimori", shell_output("#{bin}/sakimori --help")
+    require "open3"
+
+    # FIXME: Upstream does not expose a version command; replace this with a version assertion when available.
+    output, status = Open3.capture2e(bin/"sakimori", "--not-a-real-option")
+    refute_predicate status, :success?
+    assert_match "not-a-real-option", output
   end
 end


### PR DESCRIPTION
CI will validate this branch.

Improves the formula test coverage by replacing a help-output assertion with deterministic binary behavior and a precise version-command FIXME where needed.
