### PR TITLE
tapflow 0.8.2 (new formula)

### DIFF
--- a/Formula/t/tapflow.rb
+++ b/Formula/t/tapflow.rb
@@ -1,0 +1,26 @@
+class Tapflow < Formula
+  desc "Self-hosted iOS and Android simulator streaming for the whole team"
+  homepage "https://github.com/jo-duchan/tapflow"
+  url "https://registry.npmjs.org/tapflow/-/tapflow-0.8.2.tgz"
+  sha256 "54789c27df85922bf4d68e3746fcf1991d503feb03a6f441bc2177bc7e245715"
+  license "MIT"
+
+  depends_on :macos
+  depends_on "node"
+
+  on_macos do
+    depends_on macos: :tahoe
+  end
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/tapflow --version")
+
+    output = shell_output("#{bin}/tapflow admin not-a-real-subcommand 2>&1", 1)
+    assert_match "Unknown subcommand: admin not-a-real-subcommand", output
+  end
+end


### PR DESCRIPTION
Built and tested locally on macOS Sequoia. Note: dep @tapflowio/agent-core@0.8.2 published June 13 — will pass min-release-age by June 16.