### PR TITLE
holaclaw 1.2.0 (new cask)

### DIFF
--- a/Casks/h/holaclaw.rb
+++ b/Casks/h/holaclaw.rb
@@ -1,0 +1,20 @@
+cask "holaclaw" do
+  version "1.2.0"
+  sha256 :no_check
+
+  url "https://downloads.holaclaw.ai/releases/latest/holaclaw_universal.dmg"
+  name "HolaClaw"
+  desc "Personal local-first AI assistants"
+  homepage "https://holaclaw.ai/"
+
+  depends_on macos: :ventura
+  depends_on arch: :arm64
+
+  app "holaclaw.app"
+
+  zap trash: [
+    "~/Library/Application Support/HolaClaw",
+    "~/Library/Caches/HolaClaw",
+    "~/Library/Preferences/ai.holaclaw.app.plist",
+  ]
+end


### PR DESCRIPTION
Personal local-first AI assistants for macOS (Apple Silicon).