### PR TITLE
guildly 0.1.55 (new cask)

### DIFF
--- a/Casks/g/guildly.rb
+++ b/Casks/g/guildly.rb
@@ -1,0 +1,21 @@
+cask "guildly" do
+  version "0.1.55"
+  sha256 "9fa97eecbd0686108fbf7d70efe96ae03cb87ad326ccbce115c634628229a0af"
+
+  url "https://github.com/shoebum-goyell/guildly-releases/releases/download/v#{version}/Guildly-#{version}-arm64.dmg",
+      verified: "github.com/shoebum-goyell/guildly-releases/"
+  name "Guildly"
+  desc "Run a team of AI employees with human-in-the-loop control"
+  homepage "https://www.tryguildly.com/"
+
+  depends_on arch: :arm64
+  depends_on macos: :big_sur
+
+  app "Guildly.app"
+
+  zap trash: [
+    "~/Library/Application Support/Guildly",
+    "~/Library/Caches/Guildly",
+    "~/Library/Preferences/com.guildly.app.plist",
+  ]
+end


### PR DESCRIPTION
Adds the Guildly cask.

Build and test are being exercised through Homebrew CI.
