### PR TITLE
cask workflows: handle syntax-only and spellcheck cask PRs

### DIFF
--- a/.github/workflows/cask-tests.yml
+++ b/.github/workflows/cask-tests.yml
@@ -301,7 +301,10 @@ jobs:
         id: check-label
         run: |
           LABELS=$(gh pr view "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
-          if echo "$LABELS" | grep -q "^in progress$"; then
+          CASK_PR=$(gh pr view "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --json files --jq '
+            any(.files[].path; startswith("Casks/") or . == "audit_exceptions/signing_audit_skiplist.json" or . == ".typos.toml")
+          ')
+          if [ "$CASK_PR" != "true" ] || echo "$LABELS" | grep -q "^in progress$"; then
             echo "skip_label=true" >> "$GITHUB_ENV"
           else
             echo "skip_label=false" >> "$GITHUB_ENV"

--- a/.github/workflows/cask-tests.yml
+++ b/.github/workflows/cask-tests.yml
@@ -78,6 +78,9 @@ jobs:
           elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]
           then
             brew generate-cask-ci-matrix --syntax-only
+          elif jq -e '.pull_request.labels[]?.name == "CI-syntax-only"' "$GITHUB_EVENT_PATH" >/dev/null
+          then
+            brew generate-cask-ci-matrix --syntax-only
           else
             brew generate-cask-ci-matrix --url "$PULL_REQUEST_URL"
           fi

--- a/.github/workflows/publish-cask.yml
+++ b/.github/workflows/publish-cask.yml
@@ -30,8 +30,8 @@ jobs:
           fi
 
           for file in "${files[@]}"; do
-            # Cask signing exceptions are part of cask-only maintenance.
-            if [[ ! "$file" =~ ^Casks/ && "$file" != "audit_exceptions/signing_audit_skiplist.json" ]]; then
+            # Cask signing and spellcheck exceptions are part of cask-only maintenance.
+            if [[ ! "$file" =~ ^Casks/ && "$file" != "audit_exceptions/signing_audit_skiplist.json" && "$file" != ".typos.toml" ]]; then
               echo "Non-cask file detected in cask merge workflow: $file"
               exit 1
             fi


### PR DESCRIPTION
Summary:
- Skip full cask audit/install matrix generation for pull requests labeled CI-syntax-only.
- Allow .typos.toml updates in cask merge PRs for cask-specific product names.

Notes:
- This keeps intentionally syntax-only cask PRs from running install checks that the label is meant to avoid.
