### PR TITLE
open-code-review 1.3.9 (new formula)

### DIFF
--- a/Formula/o/open-code-review.rb
+++ b/Formula/o/open-code-review.rb
@@ -1,0 +1,25 @@
+class OpenCodeReview < Formula
+  desc "AI-powered code review CLI tool"
+  homepage "https://github.com/alibaba/open-code-review"
+  url "https://github.com/alibaba/open-code-review/archive/refs/tags/v1.3.9.tar.gz"
+  sha256 "2f48b58dcd3acf7910b00e92b07a4842d56b65374e810bfa21ac8ebd1d1b71d1"
+  license "Apache-2.0"
+  head "https://github.com/alibaba/open-code-review.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.Version=v#{version}"
+    system "go", "build", *std_go_args(output: bin/"ocr", ldflags:), "./cmd/opencodereview"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ocr --version")
+
+    system "git", "init"
+    (testpath/"Foo.java").write "class Foo {}\n"
+    output = shell_output("#{bin}/ocr rules check #{testpath}/Foo.java")
+    assert_match "Source: System built-in", output
+    assert_match "Pattern: **/*.java", output
+  end
+end


### PR DESCRIPTION
Summary:
- Add `open-code-review` 1.3.9 as a Go source-built formula.
- Install the documented CLI as `ocr`.

Notes:
- The npm package uses a postinstall downloader for release binaries, so the formula builds from `./cmd/opencodereview` instead.
- AI assisted with upstream/package-shape inspection and formula drafting; local Homebrew validation was run manually.
