### PR TITLE
burn: fix completion generation

### DIFF
--- a/Formula/b/burn.rb
+++ b/Formula/b/burn.rb
@@ -21,7 +21,7 @@ class Burn < Formula
     ldflags = "-s -w -X main.version=#{version} -X main.commit=#{tap.user} -X main.date=#{time.iso8601}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/burn"
 
-    generate_completions_from_executable(bin/"burn", "completion", shell_parameter_format: :cobra)
+    generate_completions_from_executable(bin/"burn", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Remove the redundant explicit `completion` argument from the Cobra completion DSL call.
- This lets Homebrew generate `burn completion <shell>` instead of `burn completion completion <shell>`.
