### PR TITLE
cpg: fix completion generation

### DIFF
--- a/Formula/c/cpg.rb
+++ b/Formula/c/cpg.rb
@@ -20,7 +20,7 @@ class Cpg < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/cpg"
 
-    generate_completions_from_executable(bin/"cpg", "completion", shell_parameter_format: :cobra)
+    generate_completions_from_executable(bin/"cpg", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Remove the redundant explicit `completion` argument from the Cobra completion DSL call.
- This lets Homebrew generate `cpg completion <shell>` instead of `cpg completion completion <shell>`.
