### PR TITLE
envy: fix completion generation

### DIFF
--- a/Formula/e/envy.rb
+++ b/Formula/e/envy.rb
@@ -19,7 +19,7 @@ class Envy < Formula
 
   def install
     system "go", "build", *std_go_args(output: bin/"envy"), "./cmd/main.go"
-    generate_completions_from_executable(bin/"envy", "completion", shell_parameter_format: :cobra)
+    generate_completions_from_executable(bin/"envy", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Remove the redundant explicit `completion` argument from the Cobra completion DSL call.
- This lets Homebrew generate `envy completion <shell>` instead of `envy completion completion <shell>`.
