### PR TITLE
gitsocial: fix completion generation

### DIFF
--- a/Formula/g/gitsocial.rb
+++ b/Formula/g/gitsocial.rb
@@ -20,7 +20,7 @@ class Gitsocial < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cli/gitsocial"
 
-    generate_completions_from_executable(bin/"gitsocial", "completion", shell_parameter_format: :cobra)
+    generate_completions_from_executable(bin/"gitsocial", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Remove the redundant explicit `completion` argument from the Cobra completion DSL call.
- This lets Homebrew generate `gitsocial completion <shell>` instead of `gitsocial completion completion <shell>`.
