### PR TITLE
togo: fix completion generation

### DIFF
--- a/Formula/t/togo.rb
+++ b/Formula/t/togo.rb
@@ -20,7 +20,7 @@ class Togo < Formula
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
-    generate_completions_from_executable(bin/"togo", "completion", shell_parameter_format: :cobra)
+    generate_completions_from_executable(bin/"togo", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Remove the redundant explicit `completion` argument from the Cobra completion DSL call.
- This lets Homebrew generate `togo completion <shell>` instead of `togo completion completion <shell>`.
