### PR TITLE
lazymake: fix completion generation

### DIFF
--- a/Formula/l/lazymake.rb
+++ b/Formula/l/lazymake.rb
@@ -25,7 +25,7 @@ class Lazymake < Formula
       -X github.com/rshelekhov/lazymake/version.Version=#{version}
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/lazymake"
-    generate_completions_from_executable(bin/"lazymake", "completion", shell_parameter_format: :cobra)
+    generate_completions_from_executable(bin/"lazymake", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Remove the redundant explicit `completion` argument from the Cobra completion DSL call.
- This lets Homebrew generate `lazymake completion <shell>` instead of `lazymake completion completion <shell>`.
