### PR TITLE
claudio: fix completion generation

### DIFF
--- a/Formula/c/claudio.rb
+++ b/Formula/c/claudio.rb
@@ -19,7 +19,9 @@ class Claudio < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/claudio"
 
-    generate_completions_from_executable(bin/"claudio", "completion", shells: [:bash, :zsh, :fish, :pwsh])
+    generate_completions_from_executable(
+      bin/"claudio", shell_parameter_format: :cobra, shells: [:bash, :zsh, :fish, :pwsh]
+    )
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra.
- Preserve PowerShell completion generation where the formula already requested it.
