### PR TITLE
dloom: fix completion generation

### DIFF
--- a/Formula/d/dloom.rb
+++ b/Formula/d/dloom.rb
@@ -24,7 +24,7 @@ class Dloom < Formula
     ]
     system "go", "build", *std_go_args(ldflags:)
 
-    generate_completions_from_executable(bin/"dloom", "completion")
+    generate_completions_from_executable(bin/"dloom", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra.
- Preserve PowerShell completion generation where the formula already requested it.
