### PR TITLE
gokin: fix completion generation

### DIFF
--- a/Formula/g/gokin.rb
+++ b/Formula/g/gokin.rb
@@ -21,7 +21,7 @@ class Gokin < Formula
     ldflags = "-s -w -X main.version=#{version}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/gokin"
 
-    generate_completions_from_executable(bin/"gokin", "completion")
+    generate_completions_from_executable(bin/"gokin", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra.
- Preserve PowerShell completion generation where the formula already requested it.
