### PR TITLE
dgop: fix completion generation

### DIFF
--- a/Formula/d/dgop.rb
+++ b/Formula/d/dgop.rb
@@ -19,7 +19,9 @@ class Dgop < Formula
     ldflags = "-s -w -X main.Version=#{version} -X main.buildTime=#{time.iso8601} -X main.commit=#{tap.user}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/dgop"
 
-    generate_completions_from_executable(bin/"dgop", "completion", shells: [:bash, :zsh, :fish, :pwsh])
+    generate_completions_from_executable(
+      bin/"dgop", shell_parameter_format: :cobra, shells: [:bash, :zsh, :fish, :pwsh]
+    )
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra.
- Preserve PowerShell completion generation where the formula already requested it.

Notes:
- Local install/test/linkage are blocked on macOS because dgop is Linux-only; audit/style/diff passed locally.
