### PR TITLE
kplane: fix completion generation

### DIFF
--- a/Formula/k/kplane.rb
+++ b/Formula/k/kplane.rb
@@ -25,7 +25,7 @@ class Kplane < Formula
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/kplane"
 
-    generate_completions_from_executable(bin/"kplane", "completion")
+    generate_completions_from_executable(bin/"kplane", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra.
- Preserve PowerShell completion generation where the formula already requested it.
