### PR TITLE
lacquer: fix completion generation

### DIFF
--- a/Formula/l/lacquer.rb
+++ b/Formula/l/lacquer.rb
@@ -34,11 +34,8 @@ class Lacquer < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/laq version")
 
-    output = shell_output("#{bin}/laq init --name 'test' " \
-                          "--description 'app test' --providers anthropic --non-interactive")
-    assert_match "Generated files", output
-    assert_path_exists testpath/"test/workflow.laq.yml"
-
-    system bin/"laq", "validate", testpath/"test/workflow.laq.yml"
+    (testpath/"empty.laq.yml").write("")
+    output = shell_output("#{bin}/laq validate #{testpath}/empty.laq.yml 2>&1", 1)
+    assert_match "Workflow file contains no content", output
   end
 end

--- a/Formula/l/lacquer.rb
+++ b/Formula/l/lacquer.rb
@@ -26,7 +26,9 @@ class Lacquer < Formula
 
     system "go", "build", *std_go_args(ldflags:, output: bin/"laq"), "./cmd/laq"
 
-    generate_completions_from_executable(bin/"laq", "completion", shells: [:bash, :zsh, :fish, :pwsh])
+    generate_completions_from_executable(
+      bin/"laq", shell_parameter_format: :cobra, shells: [:bash, :zsh, :fish, :pwsh]
+    )
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra while preserving PowerShell completions.
- Replace the network-backed init test with a deterministic local validation check.
