### PR TITLE
lathe: fix completion generation

### DIFF
--- a/Formula/l/lathe.rb
+++ b/Formula/l/lathe.rb
@@ -24,7 +24,7 @@ class Lathe < Formula
     ]
     system "go", "build", *std_go_args(ldflags:)
 
-    generate_completions_from_executable(bin/"lathe", "completion")
+    generate_completions_from_executable(bin/"lathe", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra.
- Preserve PowerShell completion generation where the formula already requested it.
