### PR TITLE
msgvault: fix completion generation

### DIFF
--- a/Formula/m/msgvault.rb
+++ b/Formula/m/msgvault.rb
@@ -29,7 +29,7 @@ class Msgvault < Formula
     system "go", "build", *std_go_args(ldflags:), "-tags", "fts5", "./cmd/msgvault"
 
     ENV["MSGVAULT_HOME"] = buildpath/".msgvault"
-    generate_completions_from_executable(bin/"msgvault", "completion")
+    generate_completions_from_executable(bin/"msgvault", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra.
- Preserve PowerShell completion generation where the formula already requested it.
