### PR TITLE
praxis: fix completion generation

### DIFF
--- a/Formula/p/praxis.rb
+++ b/Formula/p/praxis.rb
@@ -26,7 +26,7 @@ class Praxis < Formula
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/praxis"
 
-    generate_completions_from_executable(bin/"praxis", "completion")
+    generate_completions_from_executable(bin/"praxis", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra.
