### PR TITLE
anchor: fix completion generation

### DIFF
--- a/Formula/a/anchor.rb
+++ b/Formula/a/anchor.rb
@@ -39,7 +39,9 @@ class Anchor < Formula
 
     system "go", "build", *std_go_args(ldflags:), "./cmd/anchor"
 
-    generate_completions_from_executable(bin/"anchor", "completion", shells: [:bash, :zsh, :fish, :pwsh])
+    generate_completions_from_executable(
+      bin/"anchor", shell_parameter_format: :cobra, shells: [:bash, :zsh, :fish, :pwsh]
+    )
   end
 
   test do


### PR DESCRIPTION
Summary:
- Switch the Cobra completion stanza to Homebrew shell_parameter_format: :cobra.
- Preserve PowerShell completion generation where the formula already requested it.
