### PR TITLE
raiz: use typer completion helper

### DIFF
--- a/Formula/r/raiz.rb
+++ b/Formula/r/raiz.rb
@@ -105,11 +105,7 @@ class Raiz < Formula
   def install
     virtualenv_install_with_resources
 
-    # `shellingham` auto-detection doesn't work in Homebrew CI build environment so
-    # disable it to allow `typer` to use argument as shell for completions
-    # Ref: https://typer.tiangolo.com/features/#user-friendly-cli-apps
-    ENV["_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION"] = "1"
-    generate_completions_from_executable(bin/"raiz", "--show-completion")
+    generate_completions_from_executable(bin/"raiz", shell_parameter_format: :typer)
   end
 
   test do


### PR DESCRIPTION
Summary:
- Replace the manual Typer --show-completion invocation and shell-detection env override with Homebrew shell_parameter_format: :typer.
