### PR TITLE
ci: migrate Linux CI to Ubuntu 24.04

### DIFF
--- a/.github/scripts/environment.js
+++ b/.github/scripts/environment.js
@@ -21,10 +21,10 @@ module.exports = async ({github, context, core}, formula_detect) => {
         pull_number: context.issue.number
     })).data.labels : []
     const label_names = labels.map(label => label.name)
-    const linux_runner = 'ubuntu-22.04'
-    const linux_arm64_runner = 'ubuntu-22.04-arm'
+    const linux_runner = 'ubuntu-24.04'
+    const linux_arm64_runner = 'ubuntu-24.04-arm'
     const container = {
-        image: 'ghcr.io/homebrew/brew:main',
+        image: 'ghcr.io/homebrew/ubuntu24.04:main',
         options: '--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED'
     }
 

--- a/.github/scripts/environment.js
+++ b/.github/scripts/environment.js
@@ -24,6 +24,8 @@ module.exports = async ({github, context, core}, formula_detect) => {
     const linux_runner = 'ubuntu-24.04'
     const linux_arm64_runner = 'ubuntu-24.04-arm'
     const container = {
+        // Keep the generated matrix on Homebrew's main tag so formula CI follows
+        // current test-bot behavior; Renovate does not update JS-embedded digests.
         image: 'ghcr.io/homebrew/ubuntu24.04:main',
         options: '--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED'
     }

--- a/.github/workflows/clean-up-closed-prs.yml
+++ b/.github/workflows/clean-up-closed-prs.yml
@@ -28,7 +28,7 @@ jobs:
       !github.event.pull_request.merged
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/homebrew/ubuntu22.04:main@sha256:0a749ba4cb40df54bf419b07ec245f3b4c5de1dbc81feb8cbdf5db19417128cf
+      image: ghcr.io/homebrew/ubuntu24.04:main@sha256:723d76aa10cefa3767a07ce6451f41c8ec111c2158370528ec97a4516fb5a629
     permissions:
       contents: read
       actions: write # for `gh run cancel`

--- a/.github/workflows/clean-up-closed-prs.yml
+++ b/.github/workflows/clean-up-closed-prs.yml
@@ -26,7 +26,7 @@ jobs:
     if: >
       github.repository_owner == 'chenrui333' &&
       !github.event.pull_request.merged
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/homebrew/ubuntu24.04:main@sha256:723d76aa10cefa3767a07ce6451f41c8ec111c2158370528ec97a4516fb5a629
     permissions:

--- a/.github/workflows/rebottle.yml
+++ b/.github/workflows/rebottle.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, macos-15, macos-26] # build for all platforms
+        os: [ubuntu-24.04, macos-14, macos-15, macos-26] # build for all platforms
     env:
       BOTTLES_DIR: ${{ github.workspace }}/bottles
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/homebrew/brew:main@sha256:fd60ec88a7a736655d66b03b833b76f0f187e9b1d9988ae0b220be9fc732d52c
+      image: ghcr.io/homebrew/ubuntu24.04:main@sha256:723d76aa10cefa3767a07ce6451f41c8ec111c2158370528ec97a4516fb5a629
     env:
       HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
     outputs:


### PR DESCRIPTION
Summary:
- Move tap Linux CI runner labels and Homebrew containers to Ubuntu 24.04.
- Update the rebottle and closed-PR cleanup workflows to stop using Ubuntu 22.04.

References:
- Homebrew/brew#21761
- https://github.com/Homebrew/brew/releases/tag/6.0.0
