### PR TITLE
ci: retry formula list pushes

### DIFF
--- a/.github/workflows/update-formula-list.yml
+++ b/.github/workflows/update-formula-list.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
 
       - run: brew update
 
@@ -39,4 +41,23 @@ jobs:
 
       - name: Push changes back
         if: always()
-        run: git push
+        run: |
+          if git diff --quiet origin/main..HEAD; then
+            echo "No local changes to push."
+            exit 0
+          fi
+
+          for attempt in {1..3}; do
+            git fetch origin main
+            git rebase origin/main
+
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+
+            echo "Push attempt $attempt failed; retrying after refreshing main."
+            sleep "$((attempt * 5))"
+          done
+
+          echo "Failed to push generated formula list after 3 attempts." >&2
+          exit 1

--- a/.github/workflows/update-formula-list.yml
+++ b/.github/workflows/update-formula-list.yml
@@ -42,14 +42,22 @@ jobs:
       - name: Push changes back
         if: always()
         run: |
-          if git diff --quiet origin/main..HEAD; then
-            echo "No local changes to push."
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git rev-parse --verify refs/remotes/origin/main >/dev/null
+
+          if git merge-base --is-ancestor HEAD refs/remotes/origin/main; then
+            echo "No local commit to push."
             exit 0
           fi
 
           for attempt in {1..3}; do
-            git fetch origin main
-            git rebase origin/main
+            git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+            git rev-parse --verify refs/remotes/origin/main >/dev/null
+            if ! git rebase refs/remotes/origin/main; then
+              echo "Failed to rebase generated formula list onto origin/main." >&2
+              git rebase --abort || true
+              exit 1
+            fi
 
             if git push origin HEAD:main; then
               exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,6 +462,13 @@ If a helper does not match the job cleanly, fall back to the explicit `brew`/`gh
 - Formula version bumps are owned by [autobump-formula.yml](.github/workflows/autobump-formula.yml). Keep Renovate from opening `Formula/**` update PRs; if Renovate proposes a formula update, close it as a duplicate of the BrewTestBot/autobump PR or update [.github/renovate.json5](.github/renovate.json5).
 - Do not add `Casks/**` to Renovate ignore rules just to mirror `Formula/**`. Renovate's current Homebrew manager does not scan casks, and leaving `Casks/**` visible preserves future native cask support. Cask bumps remain owned by [autobump-cask.yml](.github/workflows/autobump-cask.yml) unless the repo intentionally changes policy.
 
+## Workflow Maintenance
+
+- For workflows that create commits directly on `main`, such as [update-formula-list.yml](.github/workflows/update-formula-list.yml), fetch `refs/heads/main` into `refs/remotes/origin/main` before deciding whether there is anything to push. If `HEAD` is already an ancestor of `refs/remotes/origin/main`, exit cleanly. Otherwise rebase onto `refs/remotes/origin/main` and push with a normal `git push origin HEAD:main`; never force-push `main`. Treat rebase conflicts as deterministic failures with a clear log, and retry only push rejections caused by `main` moving again.
+- For platform-aware formula build matrices, inspect changed formula files before trusting coarse triage labels. Mixed platform-only and portable formula changes, or formulae containing both `depends_on :linux` and `depends_on :macos`, must use the full matrix. Use `linux-only` or `macos-only` labels only as a fallback when formula contents cannot be inspected.
+- For workflows where a dependency job intentionally runs only on pull requests, keep non-PR events explicitly allowed through skipped dependency jobs. Do not require a PR-only job to have `success` on `push`, `schedule`, or `workflow_dispatch` events.
+- When pinning a workflow container to a specific Ubuntu generation, pin the host runner to the matching `ubuntu-<version>` label instead of `ubuntu-latest`. YAML workflow container references should use Renovate-maintained digests; JS-generated dynamic container values may use Homebrew's `main` tag only when a nearby comment explains why a floating tag is intentional.
+
 ## CI Failures
 
 - Reproduce failures locally before debugging


### PR DESCRIPTION
Summary:
- Fetch full history for the formula-list update workflow so generated commits can be rebased.
- Rebase generated README updates onto the latest origin/main before pushing, with a bounded retry loop for push races.

References:
- https://github.com/chenrui333/homebrew-tap/actions/runs/27516800002/job/81326811865
