### PR TITLE
ci: follow test-bot dependent defaults

### DIFF
--- a/.github/scripts/environment.js
+++ b/.github/scripts/environment.js
@@ -174,7 +174,7 @@ module.exports = async ({github, context, core}, formula_detect) => {
     core.setOutput('build-matrix', JSON.stringify(build_matrix_for_scope(platform_scope)))
 
     // Build test-bot arguments
-    const test_bot_formulae_args = ["--only-formulae", "--junit", "--only-json-tab", "--skip-recursive-dependents"]
+    const test_bot_formulae_args = ["--only-formulae", "--junit", "--only-json-tab"]
     test_bot_formulae_args.push('--root-url="https://ghcr.io/v2/chenrui333/tap"')
     
     if (formula_detect && formula_detect.testing_formulae) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,7 +138,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             brew test-bot ${{ needs.set-environment.outputs.test-bot-formulae-args }}
           else
-            brew test-bot --only-formulae --skip-recursive-dependents --root-url="https://ghcr.io/v2/chenrui333/tap"
+            brew test-bot --only-formulae --root-url="https://ghcr.io/v2/chenrui333/tap"
           fi
 
       - name: Post-build steps


### PR DESCRIPTION
## Summary

- stop passing the deprecated `--skip-recursive-dependents` option from pull request builds
- remove the same option from non-pull-request formula builds

## Notes

Homebrew now skips recursive dependents by default, and explicitly passing the old switch causes `brew test-bot` to exit before formula builds begin.

- [x] AI-assisted: correlated the shared failure across the affected formula PRs and applied the focused compatibility fix; manually verified the generated arguments and ran `actionlint`.
