### PR TITLE
close-superseded-prs: include casks

### DIFF
--- a/.github/workflows/close-superseded-formula-prs.yml
+++ b/.github/workflows/close-superseded-formula-prs.yml
@@ -1,4 +1,4 @@
-name: Close superseded formula PRs
+name: Close superseded package PRs
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       apply:
-        description: "Close superseded formula PRs. Disable for a dry-run."
+        description: "Close superseded formula and cask PRs. Disable for a dry-run."
         required: false
         type: boolean
         default: false
@@ -42,7 +42,7 @@ jobs:
           core: true
           cask: false
 
-      - name: Close superseded formula PRs
+      - name: Close superseded package PRs
         env:
           APPLY: ${{ github.event_name == 'schedule' || inputs.apply }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -171,18 +171,20 @@ brew check bun
 
 ## `brew close-superseded-prs`
 
-Find open formula version-bump PRs that are no longer the latest update for a
-formula, then optionally comment, label, and close them.
+Find open formula or cask version-bump PRs that are no longer the latest update
+for a package, then optionally comment, label, and close them.
 
-The command only considers PR titles in the standard formula bump format:
-`<formula> <version>`. It skips new formula/cask PRs and non-version update
-titles.
+The command only considers PR titles in the standard bump format:
+`<package> <version>`. It skips new formula/cask PRs and non-version update
+titles. Existing casks are detected from `Casks/` and compared against their
+current version in the same way as formulae.
 
 ### Usage
 
 ```bash
 brew close-superseded-prs
 brew close-superseded-prs --formula ministack
+brew close-superseded-prs --cask agent-sessions
 brew close-superseded-prs --closed-days 14
 brew close-superseded-prs --closed-limit 2000
 brew close-superseded-prs --apply
@@ -195,5 +197,5 @@ brew close-superseded-prs --apply
 - Use `--closed-days` to tune the date window, or `--closed-days 0` to ignore closed PR history.
 - Use `--closed-limit` as a GitHub API cap for the closed PR lookup.
 - Closes PRs already covered by the version on `main` with a `Superseded by current main...` comment.
-- Keeps the most recently opened bump PR for each formula and closes older open bumps with a fully qualified PR reference.
+- Keeps the most recently opened bump PR for each package and closes older open bumps with a fully qualified PR reference.
 - Uses the `superseded` label when applying changes.

--- a/cmd/brew-close-superseded-prs
+++ b/cmd/brew-close-superseded-prs
@@ -34,8 +34,12 @@ parser = OptionParser.new do |opts|
     options[:apply] = false
   end
 
-  opts.on("--formula NAME", "Only inspect one formula (can be repeated)") do |formula|
+  opts.on("--formula NAME", "Only inspect one formula or cask (can be repeated)") do |formula|
     options[:formulas] << formula
+  end
+
+  opts.on("--cask NAME", "Only inspect one cask (can be repeated)") do |cask|
+    options[:formulas] << cask
   end
 
   opts.on("--limit N", Integer, "Maximum open PRs to inspect (default: 1000)") do |limit|
@@ -100,12 +104,17 @@ def gh_json(*args)
   JSON.parse(capture!("gh", *args))
 end
 
-def formula_path(formula, root = TAP_ROOT)
+def package_info(package, root = TAP_ROOT)
   candidates = [
-    File.join(root, "Formula", formula[0], "#{formula}.rb"),
-    File.join(root, "Formula", "#{formula}.rb"),
+    [:formula, File.join(root, "Formula", package[0], "#{package}.rb")],
+    [:formula, File.join(root, "Formula", "#{package}.rb")],
+    [:cask, File.join(root, "Casks", package[0], "#{package}.rb")],
+    [:cask, File.join(root, "Casks", "#{package}.rb")],
   ]
-  candidates.find { |candidate| File.file?(candidate) }
+  type, path = candidates.find { |_, candidate| File.file?(candidate) }
+  return unless path
+
+  { type: type, path: path }
 end
 
 def tap_name(repo)
@@ -128,19 +137,28 @@ def tap_root(repo)
   @tap_roots[repo] = stdout.strip
 end
 
-def formula_version(formula, repo)
-  path = formula_path(formula, tap_root(repo)) || formula_path(formula)
-  return nil unless path
+def package_version(package, repo)
+  info = package_info(package, tap_root(repo)) || package_info(package)
+  return unless info
 
-  stdout, stderr, status = capture3("brew", "info", "--json=v2", "--formula", path, env: brew_env)
+  type = info.fetch(:type)
+  path = info.fetch(:path)
+  type_flag = type == :formula ? "--formula" : "--cask"
+
+  stdout, stderr, status = capture3("brew", "info", "--json=v2", type_flag, path, env: brew_env)
   unless status.success?
-    warn "Warning: could not determine current #{formula} version: brew info failed:\n#{stderr}"
-    return nil
+    warn "Warning: could not determine current #{package} version: brew info failed:\n#{stderr}"
+    return
   end
 
-  JSON.parse(stdout).fetch("formulae").first.fetch("versions").fetch("stable")
+  metadata = JSON.parse(stdout)
+  if type == :formula
+    metadata.fetch("formulae").first.fetch("versions").fetch("stable")
+  else
+    metadata.fetch("casks").first.fetch("version")
+  end
 rescue StandardError => e
-  warn "Warning: could not determine current #{formula} version: #{e.message}"
+  warn "Warning: could not determine current #{package} version: #{e.message}"
   nil
 end
 
@@ -188,7 +206,7 @@ def bump_prs(prs, formula_filter)
     next unless parsed
     next if formula_filter.any? && !formula_filter[parsed[:formula]]
     next if (pr_labels(pr) & SKIP_LABELS).any?
-    next unless formula_path(parsed[:formula])
+    next unless package_info(parsed[:formula])
 
     bump_prs << pr.merge(parsed)
   end
@@ -218,7 +236,7 @@ def ensure_superseded_label(repo)
     "gh", "label", "create", SUPERSEDED_LABEL,
     "--repo", repo,
     "--color", "ededed",
-    "--description", "Closed because a newer formula update supersedes this PR"
+    "--description", "Closed because a newer package update supersedes this PR"
   )
 end
 
@@ -269,7 +287,7 @@ all_bump_prs_by_formula = all_bump_prs.group_by { |pr| pr.fetch(:formula) }
 
 closures = []
 open_bump_prs.group_by { |pr| pr.fetch(:formula) }.each do |formula, formula_prs|
-  current_version = formula_version(formula, options[:repo])
+  current_version = package_version(formula, options[:repo])
   pending_prs = []
 
   formula_prs.each do |pr|
@@ -307,7 +325,7 @@ end
 closures.uniq! { |closure| closure.fetch(:number) }
 
 if closures.empty?
-  puts "No superseded formula PRs found."
+  puts "No superseded package PRs found."
   exit
 end
 
@@ -321,7 +339,7 @@ if options[:apply]
   closures.each do |closure|
     close_pr(options[:repo], closure.fetch(:number), closure.fetch(:body))
   end
-  puts "Closed #{closures.length} superseded formula PR(s)."
+  puts "Closed #{closures.length} superseded package PR(s)."
 else
   puts "Dry-run only. Re-run with --apply to close these PRs."
 end


### PR DESCRIPTION
## Summary

- detect existing casks alongside formulae in `brew close-superseded-prs`
- compare cask versions from `brew info --json=v2 --cask`
- document cask filtering and update the scheduled workflow wording

## Notes

The scheduled cleanup previously ignored cask bump families because it only searched `Formula/` and read formula version metadata. A live dry-run now identifies the older `agent-sessions` bumps while retaining the newest PR.

- [x] AI-assisted: traced the skipped cask duplicates through the helper and implemented the package-type-aware lookup; manually verified Ruby syntax, Homebrew style, `actionlint`, and live dry-run output.
