### PR TITLE
ci: support cask PRs from forks

### DIFF
--- a/.github/workflows/cask-tests.yml
+++ b/.github/workflows/cask-tests.yml
@@ -292,7 +292,10 @@ jobs:
 
   label-pr:
     needs: conclusion
-    if: success() && github.event_name == 'pull_request'
+    if: >-
+      success() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write

--- a/.github/workflows/publish-cask.yml
+++ b/.github/workflows/publish-cask.yml
@@ -12,7 +12,6 @@ jobs:
   cask-merge:
     if: |
       contains(github.event.pull_request.labels.*.name, 'pr-cask-merge') &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.type != 'Bot' &&
       github.event.pull_request.state == 'open' &&
       !github.event.pull_request.draft
@@ -44,5 +43,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          gh pr merge "$PR_NUMBER" --squash --delete-branch --repo "$GITHUB_REPOSITORY"
+          gh pr merge "$PR_NUMBER" --squash --delete-branch \
+            --match-head-commit "$PR_HEAD_SHA" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

- skip secret-backed automatic cask labeling for fork pull requests
- allow maintainers to merge a labeled fork cask PR while pinning the reviewed head SHA

## Notes

- AI-assisted: workflow diagnosis and implementation; manually verified with `actionlint` and `git diff --check`.
