### PR TITLE
ci: skip formula labeling for fork PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,10 @@ jobs:
 
   label-pr:
     needs: build-formula
-    if: success() && github.event_name == 'pull_request'
+    if: >-
+      success() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

- skip the write-capable formula labeling job for fork pull requests
- keep same-repository formula PRs on the automatic `pr-pull` labeling path

Fork pull requests cannot access `HOMEBREW_GITHUB_API_TOKEN`; maintainers can add `pr-pull` manually after reviewing a green contributor PR.
