### PR TITLE
ci: label fork pull requests during triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -15,7 +15,6 @@ jobs:
   triage:
     if: |
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.type != 'Bot' &&
       github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- allow the trusted `pull_request_target` triage job to label fork pull requests
- keep bot and closed pull requests excluded

The job uses only the static Homebrew labeler definition and GitHub API metadata; it does not check out or execute contributor code.
