### PR TITLE
ci: allow pr-pull for fork pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ jobs:
   pr-pull:
     if: |
       contains(github.event.pull_request.labels.*.name, 'pr-pull') &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.type != 'Bot' &&
       github.event.pull_request.state == 'open' &&
       !github.event.pull_request.draft


### PR DESCRIPTION
## Summary

- allow reviewed fork pull requests to enter the `pr-pull` workflow
- retain the existing bot, draft, closed-PR, and fork branch-deletion guards

The trusted `pull_request_target` job consumes CI-produced bottle artifacts by pull-request number and does not execute contributor code.
