### PR TITLE
ci: scope pr-pull concurrency to trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - labeled
 
 concurrency:
-  group: brew-pr-pull
+  group: ${{ github.event.label.name == 'pr-pull' && 'brew-pr-pull' || format('brew-pr-pull-skip-{0}', github.run_id) }}
   cancel-in-progress: false
 
 env:
@@ -15,7 +15,7 @@ env:
 jobs:
   pr-pull:
     if: |
-      contains(github.event.pull_request.labels.*.name, 'pr-pull') &&
+      github.event.label.name == 'pr-pull' &&
       github.event.pull_request.user.type != 'Bot' &&
       github.event.pull_request.state == 'open' &&
       !github.event.pull_request.draft


### PR DESCRIPTION
Only actual pr-pull label events enter the serialized publish group, so unrelated label activity cannot cancel a pending formula publish. AI-assisted: the workflow conditions were updated; GitHub Actions will validate the syntax.