### PR TITLE
ci: automate Renovate workflow digest merges

### DIFF
--- a/.github/scripts/renovate-workflow-automerge.js
+++ b/.github/scripts/renovate-workflow-automerge.js
@@ -1,0 +1,136 @@
+const REQUIRED_LABELS = ["CI-syntax-only", "dependencies", "renovate"]
+const BLOCKING_LABELS = [
+  "audit failure",
+  "automerge-skip",
+  "blocked",
+  "build failure",
+  "in progress",
+  "test failure",
+]
+const REQUIRED_CHECKS = ["GitGuardian Security Checks", "Spell Check"]
+const FAILURE_CONCLUSIONS = new Set([
+  "action_required",
+  "cancelled",
+  "failure",
+  "stale",
+  "startup_failure",
+  "timed_out",
+])
+
+function normalizePinLine(line) {
+  const action = line.match(/^(\s*(?:-\s*)?uses:\s*[^\s@]+@)[0-9a-f]{40}(\s*(?:#.*)?)$/i)
+  if (action) return `${action[1]}<commit>${action[2]}`
+
+  const image = line.match(/^(\s*image:\s*\S+@sha256:)[0-9a-f]{64}(\s*(?:#.*)?)$/i)
+  if (image) return `${image[1]}<digest>${image[2]}`
+
+  return null
+}
+
+function changedLines(patch) {
+  const additions = []
+  const deletions = []
+
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("+++ ") || line.startsWith("--- ")) continue
+    if (line.startsWith("+")) additions.push(line.slice(1))
+    if (line.startsWith("-")) deletions.push(line.slice(1))
+  }
+
+  return { additions, deletions }
+}
+
+function validateFilePatch(file) {
+  if (file.status !== "modified") {
+    return { eligible: false, reason: `${file.filename} is not a modified file` }
+  }
+  if (!/^\.github\/workflows\/[^/]+\.ya?ml$/.test(file.filename)) {
+    return { eligible: false, reason: `${file.filename} is outside .github/workflows` }
+  }
+  if (typeof file.patch !== "string" || file.patch.length === 0) {
+    return { eligible: false, reason: `${file.filename} has no complete patch` }
+  }
+
+  const { additions, deletions } = changedLines(file.patch)
+  if (file.additions !== additions.length || file.deletions !== deletions.length) {
+    return { eligible: false, reason: `${file.filename} has a truncated patch` }
+  }
+  if (additions.length === 0 || additions.length !== deletions.length) {
+    return { eligible: false, reason: `${file.filename} is not a one-for-one pin update` }
+  }
+
+  const normalizedAdditions = additions.map(normalizePinLine)
+  const normalizedDeletions = deletions.map(normalizePinLine)
+  if (normalizedAdditions.includes(null) || normalizedDeletions.includes(null)) {
+    return { eligible: false, reason: `${file.filename} changes more than action or image pins` }
+  }
+
+  normalizedAdditions.sort()
+  normalizedDeletions.sort()
+  if (JSON.stringify(normalizedAdditions) !== JSON.stringify(normalizedDeletions)) {
+    return { eligible: false, reason: `${file.filename} changes pin context, tags, or comments` }
+  }
+
+  return { eligible: true }
+}
+
+function validatePullRequest(pr, files, repository) {
+  if (pr.state !== "open") return { eligible: false, reason: "pull request is not open" }
+  if (pr.draft) return { eligible: false, reason: "pull request is a draft" }
+  if (pr.user?.login !== "renovate[bot]") {
+    return { eligible: false, reason: "pull request author is not renovate[bot]" }
+  }
+  if (pr.base?.ref !== "main") return { eligible: false, reason: "base branch is not main" }
+  if (pr.head?.repo?.full_name !== repository) {
+    return { eligible: false, reason: "pull request head is not in this repository" }
+  }
+  if (!pr.head?.ref?.startsWith("renovate/")) {
+    return { eligible: false, reason: "head branch is not a Renovate branch" }
+  }
+  if (pr.commits !== 1) return { eligible: false, reason: "pull request does not have exactly one commit" }
+  if (pr.changed_files !== files.length || files.length === 0) {
+    return { eligible: false, reason: "changed-file metadata is incomplete" }
+  }
+
+  const labels = new Set((pr.labels || []).map((label) => label.name))
+  const missingLabel = REQUIRED_LABELS.find((label) => !labels.has(label))
+  if (missingLabel) return { eligible: false, reason: `missing ${missingLabel} label` }
+
+  const blockingLabel = BLOCKING_LABELS.find((label) => labels.has(label))
+  if (blockingLabel) return { eligible: false, reason: `blocked by ${blockingLabel} label` }
+
+  for (const file of files) {
+    const result = validateFilePatch(file)
+    if (!result.eligible) return result
+  }
+
+  return { eligible: true }
+}
+
+function requiredCheckState(checkRuns) {
+  for (const name of REQUIRED_CHECKS) {
+    const matches = checkRuns.filter((check) => check.name === name)
+    if (matches.length === 0) return { state: "pending", reason: `${name} has not reported` }
+    if (matches.some((check) => check.status !== "completed")) {
+      return { state: "pending", reason: `${name} is still running` }
+    }
+
+    const failure = matches.find((check) => FAILURE_CONCLUSIONS.has(check.conclusion))
+    if (failure) return { state: "failed", reason: `${name} concluded ${failure.conclusion}` }
+    if (!matches.some((check) => check.conclusion === "success")) {
+      return { state: "pending", reason: `${name} has no successful run` }
+    }
+  }
+
+  return { state: "ready" }
+}
+
+module.exports = {
+  BLOCKING_LABELS,
+  REQUIRED_CHECKS,
+  REQUIRED_LABELS,
+  normalizePinLine,
+  requiredCheckState,
+  validateFilePatch,
+  validatePullRequest,
+}

--- a/.github/scripts/renovate-workflow-automerge.test.js
+++ b/.github/scripts/renovate-workflow-automerge.test.js
@@ -1,0 +1,125 @@
+const assert = require("node:assert/strict")
+const test = require("node:test")
+
+const {
+  requiredCheckState,
+  validateFilePatch,
+  validatePullRequest,
+} = require("./renovate-workflow-automerge.js")
+
+const repository = "chenrui333/homebrew-tap"
+
+function pullRequest(overrides = {}) {
+  return {
+    base: { ref: "main" },
+    changed_files: 1,
+    commits: 1,
+    draft: false,
+    head: { ref: "renovate/example", repo: { full_name: repository } },
+    labels: [
+      { name: "CI-syntax-only" },
+      { name: "dependencies" },
+      { name: "renovate" },
+    ],
+    state: "open",
+    user: { login: "renovate[bot]" },
+    ...overrides,
+  }
+}
+
+const actionFile = {
+  additions: 1,
+  deletions: 1,
+  filename: ".github/workflows/formula-status.yml",
+  patch: `@@ -30,1 +30,1 @@
+-        uses: Homebrew/actions/setup-homebrew@18fcb8e3e06b4247c676c506750dc95ea7226479 # main
++        uses: Homebrew/actions/setup-homebrew@100978dc923ea73ee9ed454d1d5c4fcf3ee14a9e # main`,
+  status: "modified",
+}
+
+const imageFile = {
+  additions: 1,
+  deletions: 1,
+  filename: ".github/workflows/tests.yml",
+  patch: `@@ -31,1 +31,1 @@
+-      image: ghcr.io/homebrew/ubuntu24.04:main@sha256:465a154c8c0ead8af138f9e1f1cd525b6ef59c4869f74ef9efbd9c22d7bf2859
++      image: ghcr.io/homebrew/ubuntu24.04:main@sha256:92595ffa835f692f3f6fdd3106b5d9ceb97ca321d53086bb32d6de290153a680`,
+  status: "modified",
+}
+
+test("accepts Renovate action commit and container digest updates", () => {
+  assert.deepEqual(validateFilePatch(actionFile), { eligible: true })
+  assert.deepEqual(validateFilePatch(imageFile), { eligible: true })
+
+  const files = [actionFile, imageFile]
+  assert.deepEqual(validatePullRequest(pullRequest({ changed_files: 2 }), files, repository), {
+    eligible: true,
+  })
+})
+
+test("rejects workflow edits beyond the immutable pin", () => {
+  const file = {
+    ...actionFile,
+    additions: 2,
+    deletions: 2,
+    patch: `${actionFile.patch}\n+      persist-credentials: true\n-      persist-credentials: false`,
+  }
+  assert.match(validateFilePatch(file).reason, /changes more than action or image pins/)
+  assert.match(validateFilePatch({ ...actionFile, additions: 2 }).reason, /truncated patch/)
+})
+
+test("rejects changed pin context and files outside workflows", () => {
+  const changedComment = {
+    ...actionFile,
+    patch: actionFile.patch.replace(
+      "100978dc923ea73ee9ed454d1d5c4fcf3ee14a9e # main",
+      "100978dc923ea73ee9ed454d1d5c4fcf3ee14a9e # v4",
+    ),
+  }
+  assert.equal(validateFilePatch(changedComment).eligible, false)
+  assert.equal(validateFilePatch({ ...actionFile, filename: "mise.toml" }).eligible, false)
+})
+
+test("rejects forks, non-Renovate authors, missing labels, and blocking labels", () => {
+  assert.equal(
+    validatePullRequest(
+      pullRequest({ head: { ref: "renovate/example", repo: { full_name: "fork/homebrew-tap" } } }),
+      [actionFile],
+      repository,
+    ).eligible,
+    false,
+  )
+  assert.equal(
+    validatePullRequest(pullRequest({ user: { login: "contributor" } }), [actionFile], repository).eligible,
+    false,
+  )
+  assert.equal(
+    validatePullRequest(pullRequest({ labels: [{ name: "renovate" }] }), [actionFile], repository).eligible,
+    false,
+  )
+  assert.equal(
+    validatePullRequest(
+      pullRequest({ labels: [...pullRequest().labels, { name: "automerge-skip" }] }),
+      [actionFile],
+      repository,
+    ).eligible,
+    false,
+  )
+})
+
+test("requires successful Spell Check and GitGuardian runs", () => {
+  const ready = [
+    { conclusion: "success", name: "Spell Check", status: "completed" },
+    { conclusion: "skipped", name: "Spell Check", status: "completed" },
+    { conclusion: "success", name: "GitGuardian Security Checks", status: "completed" },
+  ]
+  assert.deepEqual(requiredCheckState(ready), { state: "ready" })
+  assert.equal(requiredCheckState(ready.slice(0, 2)).state, "pending")
+  assert.equal(
+    requiredCheckState([
+      ...ready.slice(0, 2),
+      { conclusion: "failure", name: "GitGuardian Security Checks", status: "completed" },
+    ]).state,
+    "failed",
+  )
+})

--- a/.github/workflows/renovate-workflow-automerge.yml
+++ b/.github/workflows/renovate-workflow-automerge.yml
@@ -1,0 +1,207 @@
+name: Renovate workflow digest automerge
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] trusted metadata gate before read-only head checkout
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: renovate-workflow-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      eligible: ${{ steps.policy.outputs.eligible }}
+      head-sha: ${{ steps.policy.outputs.head-sha }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Check trusted Renovate digest policy
+        id: policy
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const policy = require('./.github/scripts/renovate-workflow-automerge.js')
+            const { owner, repo } = context.repo
+            const pullNumber = context.payload.pull_request.number
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            })
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            })
+            const result = policy.validatePullRequest(
+              pullRequest,
+              files,
+              `${owner}/${repo}`,
+            )
+
+            core.setOutput('eligible', result.eligible ? 'true' : 'false')
+            core.setOutput('head-sha', pullRequest.head.sha)
+            if (result.eligible) {
+              core.info(`PR #${pullNumber} is eligible at ${pullRequest.head.sha}`)
+            } else {
+              core.notice(`PR #${pullNumber} is not eligible: ${result.reason}`)
+            }
+
+  actionlint:
+    needs: classify
+    if: needs.classify.outputs.eligible == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ needs.classify.outputs.head-sha }}
+
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install_args: actionlint
+
+      - run: mise exec -- actionlint
+
+  merge:
+    needs: [classify, actionlint]
+    if: needs.classify.outputs.eligible == 'true' && needs.actionlint.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Wait for trusted checks and squash merge
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          EXPECTED_HEAD: ${{ needs.classify.outputs.head-sha }}
+        with:
+          script: |
+            const policy = require('./.github/scripts/renovate-workflow-automerge.js')
+            const { owner, repo } = context.repo
+            const pullNumber = context.payload.pull_request.number
+            const expectedHead = process.env.EXPECTED_HEAD
+            const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+            for (let attempt = 0; attempt < 60; attempt += 1) {
+              const { data: current } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullNumber,
+              })
+              if (current.merged) {
+                core.info(`PR #${pullNumber} was already merged`)
+                return
+              }
+              if (current.state !== 'open' || current.head.sha !== expectedHead) {
+                core.notice(`PR #${pullNumber} changed while checks were running; leaving it untouched`)
+                return
+              }
+
+              const checkRuns = await github.paginate(
+                github.rest.checks.listForRef,
+                { owner, repo, ref: expectedHead, per_page: 100 },
+                (response) => response.data.check_runs,
+              )
+              const checkState = policy.requiredCheckState(checkRuns)
+              if (checkState.state === 'failed') {
+                core.setFailed(checkState.reason)
+                return
+              }
+              if (checkState.state === 'ready') break
+              if (attempt === 59) {
+                core.setFailed(`Timed out waiting for checks: ${checkState.reason}`)
+                return
+              }
+
+              core.info(checkState.reason)
+              await sleep(15_000)
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            })
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            })
+            const result = policy.validatePullRequest(
+              pullRequest,
+              files,
+              `${owner}/${repo}`,
+            )
+            if (!result.eligible || pullRequest.head.sha !== expectedHead) {
+              core.notice(`PR #${pullNumber} is no longer eligible: ${result.reason || 'head changed'}`)
+              return
+            }
+
+            const review = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    mergeable
+                    reviewDecision
+                  }
+                }
+              }`,
+              { owner, repo, number: pullNumber },
+            )
+            const mergeState = review.repository.pullRequest
+            if (mergeState.reviewDecision === 'CHANGES_REQUESTED') {
+              core.setFailed('A reviewer requested changes')
+              return
+            }
+            if (mergeState.mergeable === 'CONFLICTING') {
+              core.setFailed('The pull request has merge conflicts')
+              return
+            }
+
+            try {
+              const { data: merge } = await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number: pullNumber,
+                commit_title: pullRequest.title,
+                merge_method: 'squash',
+                sha: expectedHead,
+              })
+              if (!merge.merged) core.setFailed(merge.message || 'GitHub did not merge the pull request')
+            } catch (error) {
+              const { data: latest } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullNumber,
+              })
+              if (latest.merged) {
+                core.info(`PR #${pullNumber} was merged concurrently`)
+                return
+              }
+              throw error
+            }


### PR DESCRIPTION
## Summary

- add a trusted auto-merge path for same-repository Renovate workflow pin updates
- require strict pin-only diffs plus actionlint, Spell Check, and GitGuardian
- squash-merge only the exact validated head SHA without changing formula or cask publishing

## Notes

Addresses the merge starvation seen in #9222 and #9183 while preserving the `pr-pull` bottle path.

AI-assisted: AI was used to implement and review the workflow policy. I verified the exact PR fixtures, policy tests, actionlint, and zizmor results.
