### PR TITLE
ci: uninstall casks by token

### DIFF
--- a/.github/workflows/cask-tests.yml
+++ b/.github/workflows/cask-tests.yml
@@ -250,7 +250,7 @@ jobs:
 
       - name: Run brew uninstall --cask ${{ matrix.cask.token }}
         if: always() && steps.install.outcome == 'success' && !fromJSON(steps.info.outputs.manual_installer)
-        run: brew uninstall --cask "${{ matrix.cask.path }}"
+        run: brew uninstall --cask "${{ matrix.cask.token }}"
         timeout-minutes: 30
 
       - name: Uninstall cask dependencies


### PR DESCRIPTION
Summary:
- uninstall tested casks by token after installing them from a pull-request path

Notes:
- fixes false `Cask './Casks/...' is not installed` failures after successful installs
