### PR TITLE
ci: fix Renovate check pagination

### DIFF
--- a/.github/scripts/renovate-workflow-automerge.js
+++ b/.github/scripts/renovate-workflow-automerge.js
@@ -109,7 +109,7 @@ function validatePullRequest(pr, files, repository) {
 
 function requiredCheckState(checkRuns) {
   for (const name of REQUIRED_CHECKS) {
-    const matches = checkRuns.filter((check) => check.name === name)
+    const matches = checkRuns.filter((check) => check?.name === name)
     if (matches.length === 0) return { state: "pending", reason: `${name} has not reported` }
     if (matches.some((check) => check.status !== "completed")) {
       return { state: "pending", reason: `${name} is still running` }

--- a/.github/scripts/renovate-workflow-automerge.test.js
+++ b/.github/scripts/renovate-workflow-automerge.test.js
@@ -114,6 +114,7 @@ test("requires successful Spell Check and GitGuardian runs", () => {
     { conclusion: "success", name: "GitGuardian Security Checks", status: "completed" },
   ]
   assert.deepEqual(requiredCheckState(ready), { state: "ready" })
+  assert.deepEqual(requiredCheckState([undefined, ...ready]), { state: "ready" })
   assert.equal(requiredCheckState(ready.slice(0, 2)).state, "pending")
   assert.equal(
     requiredCheckState([

--- a/.github/workflows/renovate-workflow-automerge.yml
+++ b/.github/workflows/renovate-workflow-automerge.yml
@@ -121,11 +121,12 @@ jobs:
                 return
               }
 
-              const checkRuns = await github.paginate(
-                github.rest.checks.listForRef,
-                { owner, repo, ref: expectedHead, per_page: 100 },
-                (response) => response.data.check_runs,
-              )
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+                owner,
+                repo,
+                ref: expectedHead,
+                per_page: 100,
+              })
               const checkState = policy.requiredCheckState(checkRuns)
               if (checkState.state === 'failed') {
                 core.setFailed(checkState.reason)


### PR DESCRIPTION
## Summary

- use Octokit's normalized pagination result for check runs
- tolerate malformed check-run entries while evaluating required checks

## Notes

- AI assisted with root-cause analysis and implementation.
- Manually verified with the policy unit tests and `actionlint`.
