### PR TITLE
rusticon: skip unbuildable 0.3.0

### DIFF
--- a/Formula/r/rusticon.rb
+++ b/Formula/r/rusticon.rb
@@ -6,6 +6,21 @@ class Rusticon < Formula
   license "CC-BY-NC-ND-4.0"
   head "https://github.com/ronilan/rusticon.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases do |json, regex|
+      json.filter_map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank? || match[1] == "0.3.0" # Private git dependency prevents a source build
+
+        match[1]
+      end
+    end
+  end
+
   bottle do
     root_url "https://ghcr.io/v2/chenrui333/tap"
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c4cd3d33a47473c572d81f48a48551755d1cbd4792b0f246a4ea965c45770d74"


### PR DESCRIPTION
## Summary

Keep `rusticon` at the latest source-buildable release by excluding v0.3.0 from livecheck. That release pins an inaccessible Git dependency, while later releases remain eligible for discovery.

## Notes

References #9236.

AI-assisted: diagnosed the failed source fetch and drafted the version-specific livecheck filter. Manually verified the upstream release list, livecheck result, source build, test, linkage, strict audit, and style.
