### PR TITLE
ponytail 4.9.0 (new formula)

### DIFF
--- a/Formula/ponytail.rb
+++ b/Formula/ponytail.rb
@@ -1,0 +1,30 @@
+class Ponytail < Formula
+  desc "YAGNI and minimal-implementation plugin for AI coding agents"
+  homepage "https://github.com/DietrichGebert/ponytail"
+  url "https://github.com/DietrichGebert/ponytail/archive/refs/tags/v4.9.0.tar.gz"
+  sha256 "7f45b3fab0b92ae5ff95c4608acda9f6ee2f0374b0122cba046289167d0cd256"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    libexec.install ".agents", ".claude-plugin", ".codex-plugin",
+                    "hooks", "skills", "commands", "assets",
+                    "AGENTS.md", "README.md", "LICENSE", "after-install.md",
+                    "package.json", "plugin.yaml"
+  end
+
+  test do
+    require "json"
+
+    codex_manifest = JSON.parse((libexec/".codex-plugin/plugin.json").read)
+    claude_manifest = JSON.parse((libexec/".claude-plugin/plugin.json").read)
+
+    assert_equal "ponytail", codex_manifest.fetch("name")
+    assert_equal version.to_s, codex_manifest.fetch("version")
+    assert_equal codex_manifest.fetch("version"), claude_manifest.fetch("version")
+    assert_path_exists libexec/".claude-plugin/marketplace.json"
+    assert_path_exists libexec/"hooks/claude-codex-hooks.json"
+    assert_path_exists libexec/"skills/ponytail/SKILL.md"
+  end
+end


### PR DESCRIPTION
## Summary

- add Ponytail 4.9.0 as a checksummed plugin bundle
- preserve Codex and Claude marketplace manifests under `libexec`
- keep the formula test non-executing: it validates manifests and required files only

## Validation

- `ruby -c Formula/ponytail.rb`
- `brew style Formula/ponytail.rb`
- `brew audit --strict --online ponytail` in an isolated local tap
- archive manifest/version/path validation

## Security gate

Draft only pending corporate Security review. Endpoint tooling interrupted both a Git checkout and a tar extraction of the upstream hook payload. This PR does not install, register, trust, or execute Ponytail hooks.