### PR TITLE
cliamp 2.0.1

### DIFF
--- a/Formula/c/cliamp.rb
+++ b/Formula/c/cliamp.rb
@@ -1,8 +1,8 @@
 class Cliamp < Formula
   desc "Retro terminal music player inspired by Winamp"
   homepage "https://www.cliamp.stream"
-  url "https://github.com/bjarneo/cliamp/archive/refs/tags/v1.63.2.tar.gz"
-  sha256 "968ff98c1e49bae8a0ce63acf5c77a9621ef70756a048e3df5e79454b82a9eef"
+  url "https://github.com/bjarneo/cliamp/archive/refs/tags/v2.0.1.tar.gz"
+  sha256 "2c5885665dba5ed2e8dc156bce64751199a92efed7f63959c65e985759b73732"
   license "MIT"
   head "https://github.com/bjarneo/cliamp.git", branch: "main"
 
@@ -21,6 +21,7 @@ class Cliamp < Formula
   depends_on "flac"
   depends_on "libogg"
   depends_on "libvorbis"
+  depends_on "mpg123"
   depends_on "yt-dlp"
 
   on_linux do


### PR DESCRIPTION
Updates to 2.0.1 and declares the mpg123 runtime dependency required by go-librespot on macOS and Linux.

Built and tested locally on macOS 26.6.2.

References:
- https://github.com/bjarneo/cliamp/releases/tag/v2.0.1

- [x] AI assisted with the formula edits; source checksum, local source build, runtime test, linkage, strict audit, and style were verified.
