### PR TITLE
ministack 1.5.8

### DIFF
--- a/Formula/m/ministack.rb
+++ b/Formula/m/ministack.rb
@@ -3,8 +3,8 @@ class Ministack < Formula
 
   desc "Local AWS service emulator and LocalStack replacement"
   homepage "https://github.com/ministackorg/ministack"
-  url "https://files.pythonhosted.org/packages/53/14/9c797fe0d5fafa5778ef374fe141659aea417e7520ab408df51b72b72c73/ministack-1.5.7.tar.gz"
-  sha256 "b97029a965e361f0a1c8e36c8fb3ce9866582000b85087c0e38359cd78d42c38"
+  url "https://files.pythonhosted.org/packages/d4/f0/f2e58a3e1502a0949cd02e358d9de5b9fed4549f9aafe98cb819c6f7b341/ministack-1.5.8.tar.gz"
+  sha256 "615b29041e5dedd3b506a7614dbd428a1842badcfcfe62e3d8f9059682a5840d"
   license "MIT"
   head "https://github.com/ministackorg/ministack.git", branch: "main"
 


### PR DESCRIPTION
Built and tested locally on macOS 26.6.2. Updates the PyPI source to 1.5.8 following #10892.

References:
- https://github.com/ministackorg/ministack/releases/tag/v1.5.8

- [x] AI assisted with the formula update; source checksum, source build, runtime test, linkage, strict audit, and style were verified.
