### PR TITLE
streamtop 1.5.0 (new formula)

### DIFF
--- a/Formula/s/streamtop.rb
+++ b/Formula/s/streamtop.rb
@@ -1,0 +1,21 @@
+class Streamtop < Formula
+  desc "Terminal monitor for HLS, DASH and IPTV streams"
+  homepage "https://github.com/Jorji49/streamtop"
+  url "https://github.com/Jorji49/streamtop/archive/refs/tags/v1.5.0.tar.gz"
+  sha256 "2208d73015aa2ea80c7d2603ca9938e5e93adaaa83e03c11757ae86b9b16337a"
+  license "MIT"
+  head "https://github.com/Jorji49/streamtop.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/streamtop --version")
+    (testpath/"empty.toml").write("streams = []\n")
+    output = shell_output("#{bin}/streamtop --agent #{testpath}/empty.toml 2>&1", 1)
+    assert_match "agent config has no [[streams]] entries", output
+  end
+end

--- a/Formula/s/streamtop.rb
+++ b/Formula/s/streamtop.rb
@@ -12,6 +12,12 @@ class Streamtop < Formula
     system "cargo", "install", *std_cargo_args
   end
 
+  service do
+    run [opt_bin/"streamtop", "--agent", etc/"streamtop.toml"]
+    log_path var/"log/streamtop.log"
+    error_log_path var/"log/streamtop.log"
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/streamtop --version")
     (testpath/"empty.toml").write("streams = []\n")


### PR DESCRIPTION
Packages streamtop from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 1.5.0.

References:
- https://github.com/Jorji49/streamtop/releases/tag/v1.5.0

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
