### PR TITLE
cooldeck 0.6.0 (new formula)

### DIFF
--- a/Formula/c/cooldeck.rb
+++ b/Formula/c/cooldeck.rb
@@ -1,0 +1,22 @@
+class Cooldeck < Formula
+  desc "Keyboard-driven terminal dashboard for Coolify"
+  homepage "https://github.com/Resetnak/cooldeck"
+  url "https://github.com/Resetnak/cooldeck/archive/refs/tags/v0.6.0.tar.gz"
+  sha256 "3937c5949946fdb13af0aa2712794e8f52132f812898c1d0d29875ae2fc8422c"
+  license "MIT"
+  head "https://github.com/Resetnak/cooldeck.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/resetnak/cooldeck/internal/version.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/cooldeck"
+    generate_completions_from_executable(bin/"cooldeck", shell_parameter_format: :cobra)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/cooldeck version")
+    output = shell_output("#{bin}/cooldeck --config #{testpath}/missing.toml config validate 2>&1", 1)
+    assert_match "configuration file not found", output
+  end
+end


### PR DESCRIPTION
Packages cooldeck from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.6.0.

References:
- https://github.com/Resetnak/cooldeck/releases/tag/v0.6.0

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
