### PR TITLE
mandible 0.7.0 (new formula)

### DIFF
--- a/Formula/m/mandible.rb
+++ b/Formula/m/mandible.rb
@@ -1,0 +1,21 @@
+class Mandible < Formula
+  desc "Interactive reference for installed command-line tools"
+  homepage "https://github.com/AS-FOSS/mandible"
+  url "https://github.com/AS-FOSS/mandible/archive/refs/tags/v0.7.0.tar.gz"
+  sha256 "fcb362507691bc003b3eb67170b73b78854eda03e968b67dd4bb6ad1e62a24de"
+  license any_of: ["MIT", "Apache-2.0"]
+  head "https://github.com/AS-FOSS/mandible.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "mandible")
+    generate_completions_from_executable(bin/"mandible", "--completions")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mandible --version")
+    output = shell_output("#{bin}/mandible 2>&1", 1)
+    assert_match "no tool given", output
+  end
+end


### PR DESCRIPTION
Packages mandible from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.7.0.

References:
- https://github.com/AS-FOSS/mandible/releases/tag/v0.7.0

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
