### PR TITLE
y509 1.0.4 (new formula)

### DIFF
--- a/Formula/y/y509.rb
+++ b/Formula/y/y509.rb
@@ -1,0 +1,23 @@
+class Y509 < Formula
+  desc "Inspect and validate X.509 certificate chains"
+  homepage "https://github.com/kanywst/y509"
+  url "https://github.com/kanywst/y509/archive/refs/tags/v1.0.4.tar.gz"
+  sha256 "2c0fbc80db183ef15aeb1f13183c30fa92b1903bd1b82568cd4e9383edf01e0d"
+  license "Apache-2.0"
+  head "https://github.com/kanywst/y509.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/kanywst/y509/internal/version.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/y509"
+    generate_completions_from_executable(bin/"y509", shell_parameter_format: :cobra)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/y509 --version")
+    (testpath/"invalid.pem").write("not a certificate\n")
+    output = shell_output("#{bin}/y509 --input #{testpath}/invalid.pem 2>&1", 1)
+    assert_match "certificate", output
+  end
+end


### PR DESCRIPTION
Packages y509 from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 1.0.4.

References:
- https://github.com/kanywst/y509/releases/tag/v1.0.4

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
