### PR TITLE
layerx 1.6.1 (new formula)

### DIFF
--- a/Formula/l/layerx.rb
+++ b/Formula/l/layerx.rb
@@ -1,0 +1,22 @@
+class Layerx < Formula
+  desc "Inspect Docker image layers"
+  homepage "https://github.com/deveshctl/layerx"
+  url "https://github.com/deveshctl/layerx/archive/refs/tags/v1.6.1.tar.gz"
+  sha256 "112bc3c115c817fee7d73cf0ea67542c2f9ce4fca4cc3edfe1500ee5a8cfde32"
+  license "MIT"
+  head "https://github.com/deveshctl/layerx.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags:)
+    generate_completions_from_executable(bin/"layerx", shell_parameter_format: :cobra)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/layerx --version")
+    output = shell_output("#{bin}/layerx --engine invalid example 2>&1", 2)
+    assert_match 'invalid engine "invalid"', output
+  end
+end


### PR DESCRIPTION
Packages layerx from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 1.6.1.

References:
- https://github.com/deveshctl/layerx/releases/tag/v1.6.1

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
