### PR TITLE
ku 0.11.0 (new formula)

### DIFF
--- a/Formula/k/ku.rb
+++ b/Formula/k/ku.rb
@@ -1,0 +1,22 @@
+class Ku < Formula
+  desc "Keyboard-driven Kubernetes terminal interface"
+  homepage "https://github.com/bjarneo/ku"
+  url "https://github.com/bjarneo/ku/archive/refs/tags/v0.11.0.tar.gz"
+  sha256 "91711676494a37ed73d72bb375dfdecf6f382eb42cff7463ed9af6e35e152294"
+  license "MIT"
+  head "https://github.com/bjarneo/ku.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags:)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ku --version")
+    (testpath/"kubeconfig").write("")
+    output = shell_output("#{bin}/ku --check --kubeconfig #{testpath}/kubeconfig 2>&1", 1)
+    assert_match "kubeconfig is empty or missing", output
+  end
+end

--- a/Formula/k/ku.rb
+++ b/Formula/k/ku.rb
@@ -9,7 +9,7 @@ class Ku < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w -X main.version=#{version}"
+    ldflags = "-s -w -X main.version=v#{version}"
     system "go", "build", *std_go_args(ldflags:)
   end
 


### PR DESCRIPTION
Packages ku from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.11.0.

References:
- https://github.com/bjarneo/ku/releases/tag/v0.11.0

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
