### PR TITLE
drydock 1.1.2 (new formula)

### DIFF
--- a/Formula/d/drydock.rb
+++ b/Formula/d/drydock.rb
@@ -1,0 +1,21 @@
+class Drydock < Formula
+  desc "Dashboard for a fleet of Git repositories"
+  homepage "https://github.com/yetidevworks/drydock"
+  url "https://github.com/yetidevworks/drydock/archive/refs/tags/v1.1.2.tar.gz"
+  sha256 "73a2287223e8a9da874daac56bb2a198827994c0b8702b408026097c96cae151"
+  license "MIT"
+  head "https://github.com/yetidevworks/drydock.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "git"
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/drydock")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/drydock --version")
+    output = shell_output("#{bin}/drydock config show")
+    assert_match 'roots = ["~/Projects"]', output
+  end
+end

--- a/Formula/d/drydock.rb
+++ b/Formula/d/drydock.rb
@@ -7,7 +7,6 @@ class Drydock < Formula
   head "https://github.com/yetidevworks/drydock.git", branch: "main"
 
   depends_on "rust" => :build
-  depends_on "git"
 
   def install
     system "cargo", "install", *std_cargo_args(path: "crates/drydock")


### PR DESCRIPTION
Packages drydock from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 1.1.2.

References:
- https://github.com/yetidevworks/drydock/releases/tag/v1.1.2

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
