### PR TITLE
amdtop 0.2.6 (new formula)

### DIFF
--- a/Formula/a/amdtop.rb
+++ b/Formula/a/amdtop.rb
@@ -8,8 +8,8 @@ class Amdtop < Formula
 
   depends_on "rust" => :build
   depends_on "pkgconf" => :build
-  depends_on :linux
   depends_on "libdrm"
+  depends_on :linux
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/a/amdtop.rb
+++ b/Formula/a/amdtop.rb
@@ -6,8 +6,8 @@ class Amdtop < Formula
   license "Apache-2.0"
   head "https://github.com/lhl/amdtop.git", branch: "main"
 
-  depends_on "rust" => :build
   depends_on "pkgconf" => :build
+  depends_on "rust" => :build
   depends_on "libdrm"
   depends_on :linux
 

--- a/Formula/a/amdtop.rb
+++ b/Formula/a/amdtop.rb
@@ -1,0 +1,23 @@
+class Amdtop < Formula
+  desc "Monitor AMD GPUs, CPUs and NPUs"
+  homepage "https://github.com/lhl/amdtop"
+  url "https://github.com/lhl/amdtop/archive/refs/tags/v0.2.6.tar.gz"
+  sha256 "fda067b61130fdcf01370cd311dec8a4020fc31459de20dede41302e118362db"
+  license "Apache-2.0"
+  head "https://github.com/lhl/amdtop.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "pkgconf" => :build
+  depends_on :linux
+  depends_on "libdrm"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/amdtop --version")
+    output = shell_output("#{bin}/amdtop --invalid-option 2>&1", 1)
+    assert_match "unknown option: --invalid-option", output
+  end
+end


### PR DESCRIPTION
Packages amdtop from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.2.6.

References:
- https://github.com/lhl/amdtop/releases/tag/v0.2.6

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
