### PR TITLE
lsoff 0.1.4 (new formula)

### DIFF
--- a/Formula/l/lsoff.rb
+++ b/Formula/l/lsoff.rb
@@ -1,0 +1,20 @@
+class Lsoff < Formula
+  desc "List listening TCP and UDP ports"
+  homepage "https://github.com/yutat23/lsoff"
+  url "https://github.com/yutat23/lsoff/archive/refs/tags/v0.1.4.tar.gz"
+  sha256 "c99f1a01375dac9506e48f612f680d21ffce502aea5db816b78c45002e99ed98"
+  license "MIT"
+  head "https://github.com/yutat23/lsoff.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/lsoff --version")
+    output = shell_output("#{bin}/lsoff --kill 2>&1", 2)
+    assert_match "-k requires a port", output
+  end
+end


### PR DESCRIPTION
Packages lsoff from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.1.4.

References:
- https://github.com/yutat23/lsoff/releases/tag/v0.1.4

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
