### PR TITLE
xql 1.12.0 (new formula)

### DIFF
--- a/Formula/x/xql.rb
+++ b/Formula/x/xql.rb
@@ -16,6 +16,6 @@ class Xql < Formula
     assert_match version.to_s, shell_output("#{bin}/xql --version")
     (testpath/"input.csv").write("name\nalice\n")
     output = shell_output("#{bin}/xql csv #{testpath}/input.csv --exec 'SELECT name' --mode=csv")
-    assert_equal "name\nalice\n", output
+    assert_equal %w[name alice], output.lines.map(&:strip)
   end
 end

--- a/Formula/x/xql.rb
+++ b/Formula/x/xql.rb
@@ -1,0 +1,21 @@
+class Xql < Formula
+  desc "Query CSV files and SharePoint Lists with SQL"
+  homepage "https://github.com/excelano/xql"
+  url "https://github.com/excelano/xql/archive/refs/tags/v1.12.0.tar.gz"
+  sha256 "f3a1b4b0663290a6e257f0d7d5e0962709c877d375d5976f2117c13f80f6ae1b"
+  license "MIT"
+  head "https://github.com/excelano/xql.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/xql"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/xql --version")
+    (testpath/"input.csv").write("name\nalice\n")
+    output = shell_output("#{bin}/xql csv #{testpath}/input.csv --exec 'SELECT name' --mode=csv")
+    assert_equal "name\nalice\n", output
+  end
+end


### PR DESCRIPTION
Packages xql from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 1.12.0.

References:
- https://github.com/excelano/xql/releases/tag/v1.12.0

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
