### PR TITLE
flow-network 0.2.5 (new formula)

### DIFF
--- a/Formula/f/flow-network.rb
+++ b/Formula/f/flow-network.rb
@@ -1,0 +1,21 @@
+class FlowNetwork < Formula
+  desc "Real-time network throughput dashboard"
+  homepage "https://github.com/programmersd21/flow"
+  url "https://github.com/programmersd21/flow/archive/refs/tags/v0.2.5.tar.gz"
+  sha256 "be7b6dbfdcdaa393f0e86cddefb209a58228a172f6a2ff7cf63f67edaedb3514"
+  license "MIT"
+  head "https://github.com/programmersd21/flow.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/flow"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/flow-network --version")
+    output = JSON.parse(shell_output("#{bin}/flow-network --json --refresh 10ms"))
+    assert_equal "ok", output.fetch("status")
+    assert_operator output.fetch("download_bps"), :>=, 0
+  end
+end


### PR DESCRIPTION
Packages flow-network from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.2.5.

References:
- https://github.com/programmersd21/flow/releases/tag/v0.2.5

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
