### PR TITLE
keyward 1.0.3 (new formula)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -13,6 +13,7 @@ extend-ignore-re = [
 ]
 
 [default.extend-words]
+keyward = "keyward" # upstream project name
 Hashi = "Hashi" 
 Sur = "Sur" 
 debugg = "debugg" # for debugg-ai-mcp filename

--- a/Formula/k/keyward.rb
+++ b/Formula/k/keyward.rb
@@ -1,0 +1,20 @@
+class Keyward < Formula
+  desc "Manage SSH keys and audit SSH configuration"
+  homepage "https://github.com/gateway-of-last-resort/keyward"
+  url "https://github.com/gateway-of-last-resort/keyward/archive/refs/tags/v1.0.3.tar.gz"
+  sha256 "0b726b18bfe8dc3b8c0d06ce2f833a35c7f35279b2440e70bced5acc7004c8c8"
+  license "MIT"
+  head "https://github.com/gateway-of-last-resort/keyward.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/keyward"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/keyward --version")
+    (testpath/".ssh").mkpath
+    assert_empty JSON.parse(shell_output("#{bin}/keyward list --json"))
+  end
+end


### PR DESCRIPTION
Packages keyward from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 1.0.3.

References:
- https://github.com/gateway-of-last-resort/keyward/releases/tag/v1.0.3

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
