### PR TITLE
justray 1.4.5 (new formula)

### DIFF
--- a/Formula/j/justray.rb
+++ b/Formula/j/justray.rb
@@ -1,0 +1,35 @@
+class Justray < Formula
+  desc "Terminal VPN client"
+  homepage "https://github.com/luynrs/justray"
+  url "https://github.com/luynrs/justray/archive/refs/tags/v1.4.5.tar.gz"
+  sha256 "0913901f21cf1a68fea7554fdb15f3bcec80cbf43f1583e293c9d564fc880dbb"
+  license "GPL-3.0-only"
+  head "https://github.com/luynrs/justray.git", branch: "main"
+
+  # Match upstream release CI while sing-box relies on private HTTP/2 symbols.
+  depends_on "go@1.26" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/luynrs/justray/internal/version.Version=#{version}"
+    tags = "with_quic,with_utls,with_gvisor,with_grpc,with_xhttp"
+    %w[justray justrayd].each do |name|
+      system "go", "build", *std_go_args(output: bin/name, ldflags:), "-tags=#{tags}", "./cmd/#{name}"
+    end
+    bin.install_symlink "justray" => "jray"
+    generate_completions_from_executable(bin/"justray", shell_parameter_format: :cobra)
+  end
+
+  service do
+    run [opt_bin/"justrayd"]
+    keep_alive true
+    log_path var/"log/justrayd.log"
+    error_log_path var/"log/justrayd.log"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/justray --version")
+    assert_path_exists bin/"justrayd"
+    output = shell_output("#{bin}/justray invalid-command 2>&1", 1)
+    assert_match 'unknown command "invalid-command"', output
+  end
+end


### PR DESCRIPTION
Packages justray from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 1.4.5.

References:
- https://github.com/luynrs/justray/releases/tag/v1.4.5

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.

Uses Go 1.26 to match upstream release CI while sing-box relies on private HTTP/2 symbols. The full transport feature set is retained.
