### PR TITLE
panix 0.9.2 (new formula)

### DIFF
--- a/Formula/p/panix.rb
+++ b/Formula/p/panix.rb
@@ -1,0 +1,21 @@
+class Panix < Formula
+  desc "Deploy Nix configurations across machines"
+  homepage "https://github.com/mihakrumpestar/panix"
+  url "https://github.com/mihakrumpestar/panix/archive/refs/tags/v0.9.2.tar.gz"
+  sha256 "ca2f052d74372ecb2c8ddbc6e67183923aab42ea53a385c66aee6aa0fa3dca25"
+  license "AGPL-3.0-only"
+  head "https://github.com/mihakrumpestar/panix.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args, "./cmd/panix"
+    generate_completions_from_executable(bin/"panix", "completion", "--code")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/panix --version")
+    output = shell_output("#{bin}/panix schema --output -")
+    assert_match "Panix Configuration Schema", output
+  end
+end


### PR DESCRIPTION
Packages panix from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.9.2.

References:
- https://github.com/mihakrumpestar/panix/releases/tag/v0.9.2

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
