### PR TITLE
spotatui 0.41.0 (new formula)

### DIFF
--- a/Formula/s/spotatui.rb
+++ b/Formula/s/spotatui.rb
@@ -1,0 +1,28 @@
+class Spotatui < Formula
+  desc "Terminal music player for Spotify and local media"
+  homepage "https://github.com/LargeModGames/spotatui"
+  url "https://github.com/LargeModGames/spotatui/archive/refs/tags/v0.41.0.tar.gz"
+  sha256 "2fde33172d570c13c99f51037bc67b556de12c656bbe4e4e46e8ef8d01575e5d"
+  license "MIT"
+  head "https://github.com/LargeModGames/spotatui.git", branch: "main"
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+
+  on_linux do
+    depends_on "alsa-lib"
+    depends_on "openssl@3"
+  end
+
+  def install
+    system "cargo", "install", *std_cargo_args
+    generate_completions_from_executable(bin/"spotatui", "--completions")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/spotatui --version")
+    output = shell_output("#{bin}/spotatui history recap --output #{testpath}/recap.html")
+    assert_match "Generated recap from 0 qualified listens", output
+    assert_path_exists testpath/"recap.html"
+  end
+end

--- a/Formula/s/spotatui.rb
+++ b/Formula/s/spotatui.rb
@@ -8,6 +8,7 @@ class Spotatui < Formula
 
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
+  depends_on "portaudio"
 
   on_linux do
     depends_on "alsa-lib"


### PR DESCRIPTION
Packages spotatui from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.41.0.

References:
- https://github.com/LargeModGames/spotatui/releases/tag/v0.41.0

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
