### PR TITLE
papr 0.1.1 (new formula)

### DIFF
--- a/Formula/p/papr.rb
+++ b/Formula/p/papr.rb
@@ -1,0 +1,22 @@
+class Papr < Formula
+  desc "Terminal workspace for academic research"
+  homepage "https://github.com/AfrozSaqlain/Papr"
+  url "https://github.com/AfrozSaqlain/Papr/archive/refs/tags/v0.1.1.tar.gz"
+  sha256 "e5648239d6632634bd3dfe2c504147f509f26224943d41c5272815b13e3ed81c"
+  license "MIT"
+  head "https://github.com/AfrozSaqlain/Papr.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/papr")
+    generate_completions_from_executable(bin/"papr", "completions")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/papr --version")
+    output = shell_output("#{bin}/papr paths")
+    assert_match "database:", output
+    assert_match "projects:", output
+  end
+end


### PR DESCRIPTION
Packages papr from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.1.1.

References:
- https://github.com/AfrozSaqlain/Papr/releases/tag/v0.1.1

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
