### PR TITLE
asmdiff 0.3.3 (new formula)

### DIFF
--- a/Formula/a/asmdiff.rb
+++ b/Formula/a/asmdiff.rb
@@ -16,6 +16,8 @@ class Asmdiff < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/asmdiff --version")
-    assert_match "SOURCE.c required", shell_output("#{bin}/asmdiff 2>&1", 2)
+    (testpath/"test.c").write "int add(int x) { return x + 1; }\n"
+    output = shell_output("#{bin}/asmdiff test.c --cc '#{ENV.cc} -O2' --filter 'add$' --json")
+    assert_match(/"_?add"/, output)
   end
 end

--- a/Formula/a/asmdiff.rb
+++ b/Formula/a/asmdiff.rb
@@ -1,0 +1,21 @@
+class Asmdiff < Formula
+  include Language::Python::Virtualenv
+
+  desc "Compare per-function assembly across compilers"
+  homepage "https://github.com/rt-rtos/asmdiff"
+  url "https://files.pythonhosted.org/packages/8d/12/b91bac1948f7b90192a1e94366499a01a59fa048a61f5124bcecfc4c6851/asmdiff-0.3.3.tar.gz"
+  sha256 "6313ac2adb5f903d4a4e30c288d4f23095ef92575429d3e1ad3a0ac1eabc6976"
+  license "MIT"
+  head "https://github.com/rt-rtos/asmdiff.git", branch: "main"
+
+  depends_on "python@3.14"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/asmdiff --version")
+    assert_match "SOURCE.c required", shell_output("#{bin}/asmdiff 2>&1", 2)
+  end
+end


### PR DESCRIPTION
Packages asmdiff from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.3.3.

References:
- https://pypi.org/project/asmdiff/0.3.3/

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
