### PR TITLE
swpui 0.10.1 (new formula)

### DIFF
--- a/Formula/s/swpui.rb
+++ b/Formula/s/swpui.rb
@@ -1,0 +1,22 @@
+class Swpui < Formula
+  desc "Interactive search and replacement preview"
+  homepage "https://github.com/beeb/swpui"
+  url "https://github.com/beeb/swpui/archive/refs/tags/v0.10.1.tar.gz"
+  sha256 "517a8f19498d3e5d689baabb7e48001aba81042c727010491fec27c092cd236d"
+  license any_of: ["MIT", "Apache-2.0"]
+  head "https://github.com/beeb/swpui.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    # TODO: Upstream does not expose a version command.
+    # FIXME: Replace the terminal startup failure check when upstream adds a headless preview mode.
+    output = shell_output("#{bin}/swpui </dev/null 2>&1", 101)
+    assert_match "failed to initialize terminal", output
+    assert_match "panicked", output
+  end
+end

--- a/Formula/s/swpui.rb
+++ b/Formula/s/swpui.rb
@@ -15,8 +15,8 @@ class Swpui < Formula
   test do
     # TODO: Upstream does not expose a version command.
     # FIXME: Replace the terminal startup failure check when upstream adds a headless preview mode.
-    output = shell_output("#{bin}/swp </dev/null 2>&1", 101)
-    assert_match "failed to initialize terminal", output
-    assert_match "panicked", output
+    output = shell_output("#{bin}/swp </dev/null 2>&1", 1)
+    assert_match version.to_s, output
+    assert_match "Failed to initialize input reader", output
   end
 end

--- a/Formula/s/swpui.rb
+++ b/Formula/s/swpui.rb
@@ -15,7 +15,7 @@ class Swpui < Formula
   test do
     # TODO: Upstream does not expose a version command.
     # FIXME: Replace the terminal startup failure check when upstream adds a headless preview mode.
-    output = shell_output("#{bin}/swpui </dev/null 2>&1", 101)
+    output = shell_output("#{bin}/swp </dev/null 2>&1", 101)
     assert_match "failed to initialize terminal", output
     assert_match "panicked", output
   end

--- a/Formula/s/swpui.rb
+++ b/Formula/s/swpui.rb
@@ -14,9 +14,10 @@ class Swpui < Formula
 
   test do
     # TODO: Upstream does not expose a version command.
-    # FIXME: Replace the terminal startup failure check when upstream adds a headless preview mode.
-    output = shell_output("#{bin}/swp </dev/null 2>&1", 1)
-    assert_match version.to_s, output
-    assert_match "Failed to initialize input reader", output
+    # FIXME: Replace the startup error check when upstream adds a headless preview mode.
+    (testpath/"swpui.log").mkpath
+    output = shell_output("DEBUG=1 #{bin}/swp 2>&1", 1)
+    assert_match "Is a directory", output
+    assert_predicate testpath/"swpui.log", :directory?
   end
 end


### PR DESCRIPTION
Packages swpui from upstream source. Build and runtime checks are delegated to GitHub Actions; livecheck reports 0.10.1.

References:
- https://github.com/beeb/swpui/releases/tag/v0.10.1

- [x] AI assistance: formula preparation and upstream review; source checksum, build configuration, test paths and livecheck checked before submission.
