### PR TITLE
epiq 1.8.1

### DIFF
--- a/Formula/e/epiq.rb
+++ b/Formula/e/epiq.rb
@@ -1,8 +1,8 @@
 class Epiq < Formula
   desc "Distributed terminal-native issue tracker backed by Git"
   homepage "https://github.com/ljtn/epiq"
-  url "https://registry.npmjs.org/epiq/-/epiq-1.7.2.tgz"
-  sha256 "8b0d46cb1208d43d16cf7d9611744cce31b0ed93a772141f2b38b90870b04f99"
+  url "https://registry.npmjs.org/epiq/-/epiq-1.8.1.tgz"
+  sha256 "f3a6ba48fae3264b0e8ac17fb7b4719afa9879fd424bdd60f6f147266c1546bd"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Updates epiq to 1.8.1. Source checksum and livecheck verified; build checks run in GitHub Actions.

References:
- https://www.npmjs.com/package/epiq/v/1.8.1

- [x] AI assistance: formula update and source review; checksum and livecheck verified, with build and test checks performed by GitHub Actions.
