### PR TITLE
ci: trust tap before publishing bottles

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,9 @@ jobs:
           core: true
           cask: false
 
+      - name: Trust this tap
+        run: brew trust --tap "$GITHUB_REPOSITORY"
+
       - name: Set up git
         uses: Homebrew/actions/git-user-config@fc695c54c2032716dd4cedd007489c8e32fc8a5d
         with:


### PR DESCRIPTION
The bottle publish job fails with “Refusing to load formula ... from untrusted tap” after successful formula builds. Explicitly trust this repository on the publish runner before `brew pr-pull` loads its formulae.

- [x] AI assistance: workflow repair; checked the failing publish log, Homebrew trust command, and actionlint.
