### PR TITLE
ci: queue pending bottle publishing runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 concurrency:
   group: ${{ github.event.label.name == 'pr-pull' && 'brew-pr-pull' || format('brew-pr-pull-skip-{0}', github.run_id) }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   pr-pull:


### PR DESCRIPTION
Preserve pending bottle publication runs when several formula builds finish together. The default concurrency queue cancels older pending `pr-pull` runs; `queue: max` retains them while keeping one publisher active.

References:
- https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/

- [x] AI assistance: workflow repair; verified cancelled publish runs and GitHub's documented queue syntax. The installed actionlint predates `queue`; remaining lint checks pass with only that unsupported-key diagnostic excluded.
