### PR TITLE
ci: scope actionlint queue compatibility

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/publish.yml:
+    ignore:
+      # GitHub supports this setting; actionlint 1.7.12 does not yet recognize it.
+      # Remove after https://github.com/rhysd/actionlint/issues/657 is released.
+      - '^unexpected key "queue" for "concurrency" section\.'


### PR DESCRIPTION
Scope the actionlint compatibility exception to the `queue` key in `publish.yml`. GitHub supports this setting, but the latest actionlint release rejects it and blocks Renovate workflow PRs such as #10961. All other diagnostics remain enabled; local actionlint passes.

References:
- https://github.com/rhysd/actionlint/issues/657
- https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/

- [x] AI-assisted: prepared the scoped configuration; verified the failing CI log, current upstream release and documentation, and ran actionlint locally.
