### PR TITLE
ci: prepare unbottled Intel dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,19 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: ${{ matrix.cleanup }}
 
+      - name: Prepare Intel macOS dependencies
+        if: github.event_name == 'pull_request' && matrix.runner == 'macos-15-intel'
+        env:
+          TESTING_FORMULAE: ${{ needs.tap-syntax.outputs.testing_formulae }}
+          HOMEBREW_NO_INSTALL_FROM_API: 1
+        run: |
+          # Build unavailable dependency bottles from source before --build-bottle.
+          # The formula itself is still built, bottled and tested by test-bot below.
+          if [[ -n "$TESTING_FORMULAE" ]]; then
+            IFS=',' read -r -a formulae <<< "$TESTING_FORMULAE"
+            brew install --formula --only-dependencies --include-test -- "${formulae[@]}"
+          fi
+
       - name: Run brew test-bot
         id: brew-test-bot-formulae
         working-directory: ${{ env.BOTTLES_DIR }}


### PR DESCRIPTION
Prepare dependencies before Intel macOS PR bottle builds. Missing core bottles currently stop #10940, #10754 and #9639 before their formula builds begin; a separate dependency install allows Homebrew to build those dependencies from source.

The existing formula build, bottle, linkage, audit and test steps remain unchanged. Local actionlint passes; the affected PRs will exercise the dependency preparation in GitHub Actions after refresh.

- [x] AI-assisted: prepared the scoped CI step; checked the three failing logs, Homebrew dependency-install behavior and test-bot output format, and ran actionlint locally.
