### PR TITLE
ci: opt in to source dependency builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,12 +122,15 @@ jobs:
           cleanup: ${{ matrix.cleanup }}
 
       - name: Prepare Intel macOS dependencies
-        if: github.event_name == 'pull_request' && matrix.runner == 'macos-15-intel'
+        if: >-
+          github.event_name == 'pull_request' &&
+          matrix.runner == 'macos-15-intel' &&
+          contains(github.event.pull_request.labels.*.name, 'CI-source-dependencies')
         env:
           TESTING_FORMULAE: ${{ needs.tap-syntax.outputs.testing_formulae }}
           HOMEBREW_NO_INSTALL_FROM_API: 1
         run: |
-          # Build unavailable dependency bottles from source before --build-bottle.
+          # Opt in when missing dependency bottles have a practical source build.
           # The formula itself is still built, bottled and tested by test-bot below.
           if [[ -n "$TESTING_FORMULAE" ]]; then
             IFS=',' read -r -a formulae <<< "$TESTING_FORMULAE"


### PR DESCRIPTION
Require `CI-source-dependencies` for the Intel dependency-preparation step. This keeps the tested fallback available for missing libraries without automatically building unavailable Go/Rust toolchains on every PR.

Asmdiff, Breathe CLI and Kaydet are opted in. Asmdiff has passed its complete Intel build; the other two formula checks are still running. Local actionlint passes.

- [x] AI-assisted: scoped the existing step; checked Intel logs, verified Asmdiff's source-built dependencies and full CI result, and ran actionlint locally.
