### PR TITLE
ci: trust the cask under test

### DIFF
--- a/.github/workflows/cask-tests.yml
+++ b/.github/workflows/cask-tests.yml
@@ -113,6 +113,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Trust the cask under test
+        if: matrix.cask
+        env:
+          CASK_UNDER_TEST: ${{ matrix.tap }}/${{ matrix.cask.token }}
+        run: brew trust --cask "$CASK_UNDER_TEST"
+
       - name: Clean up CI machine
         if: runner.os == 'macOS'
         run: brew test-bot --cleanup --only-cleanup-before


### PR DESCRIPTION
Cask jobs fail with “Refusing to load cask … from untrusted tap” after removal of the deprecated trust bypass. Explicitly trust the individual cask under test before auditing and uninstalling it.

Required for #9956.

- [x] AI assisted with the workflow change; manually inspected runner logs and checked the diff with actionlint.
